### PR TITLE
GCW-2052 Modification of order which is not created by current logged in user bug

### DIFF
--- a/app/controllers/subscription.js
+++ b/app/controllers/subscription.js
@@ -124,6 +124,14 @@ export default Ember.Controller.extend({
 
     var type = Object.keys(data.item)[0];
     var item = Ember.$.extend({}, data.item[type]);
+
+    //Returning false if order is not created by current logged-in user
+    if(type.toLowerCase() === "order") {
+      if(item.created_by_id !== parseInt(this.session.get("currentUser.id"))) {
+        return false;
+      }
+    }
+
     if(type === "package" || type === "Package") {
       this.get("browse").toggleProperty("packageCategoryReloaded");
     }


### PR DESCRIPTION
Hi Team,

This PR fixes live update issue.
- When User is logged in to Browse App any any other order is updated on Stock App then Browse App shows that order on my_orders page with "something went wrong" pop up.
- This PR fixes this issue of live update.

Jira ticket:- https://jira.crossroads.org.hk/browse/GCW-2052

Please review it and let me know if any other changes are required.
Thanks