### PR TITLE
android deployment steps added before ios deployment

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -52,10 +52,10 @@ deployment:
     branch: master
     commands:
       - bundle exec cap staging deploy
-      - bundle exec rake staging ios app:build
-      - bundle exec fastlane ios staging
       - bundle exec rake staging android app:build
       - bundle exec fastlane android staging
+      - bundle exec rake staging ios app:build
+      - bundle exec fastlane ios staging
       - curl https://api.rollbar.com/api/1/sourcemap/download -F access_token=$ROLLBAR_KEY -F version=$APP_VERSION -F minified_url=https://browse-staging.goodcity.hk/assets/browse.js
   production:
     branch: live


### PR DESCRIPTION
Hi Team,
This PR is related to android building issue of jira ticket https://jira.crossroads.org.hk/browse/GCW-2038.
Circle CI build is failing at ios build because of which android build is not executed. To make it work android build steps are added before ios steps.
If any change is required, let me know.
Thanks.