### PR TITLE
GCW-2195 Lazy shallow order loading

### DIFF
--- a/app/routes/my_orders.js
+++ b/app/routes/my_orders.js
@@ -20,7 +20,7 @@ export default AuthorizeRoute.extend({
     return Ember.RSVP.hash({
       organisation: this.store.peekAll('organisation').objectAt(0),
       user: this.store.peekAll('user').objectAt(0),
-      orders: this.store.peekAll('order')
+      orders: this.store.query('order', { shallow: true })
     });
   },
 

--- a/app/templates/my_orders.hbs
+++ b/app/templates/my_orders.hbs
@@ -1,23 +1,19 @@
 <div class="row my_orders">
   <div class="title">{{t "my_orders.my_orders"}}</div>
   <div class="row order-heading">
-    <div class="small-4 columns">{{t "my_orders.order_no"}}</div>
-    <div class="small-4 columns">{{t "my_orders.order_state"}}</div>
-    <div class="small-4 columns">{{t "my_orders.item_count"}}</div>
+    <div class="small-6 columns">{{t "my_orders.order_no"}}</div>
+    <div class="small-6 columns">{{t "my_orders.order_state"}}</div>
   </div>
   <div class="small-12 columns">
     <ul class="list list-items">
       {{#each arrangedOrders as |order|}}
         <li {{action "setOrder" order}}>
           <div class="row">
-            <div class="small-4 columns">
+            <div class="small-6 columns">
               {{order.code}}
             </div>
-            <div class="small-4 columns">
+            <div class="small-6 columns">
               {{t order.updatedState}}
-            </div>
-            <div class="small-4 columns">
-              {{order.orderItems.length}}
             </div>
           </div>
         </li>

--- a/config/environment.js
+++ b/config/environment.js
@@ -55,7 +55,7 @@ module.exports = function(environment) {
       NAMESPACE: 'api/v1',
       HK_COUNTRY_CODE: '+852',
       PRELOAD_TYPES: ["package_type", "district", "territory", "package_category", "donor_condition", "package"],
-      PRELOAD_AUTHORIZED_TYPES: ["order", "gogovan_transport"],
+      PRELOAD_AUTHORIZED_TYPES: ["gogovan_transport"],
 
       SHA: process.env.APP_SHA || "00000000",
       VERSION: "1.0.0"


### PR DESCRIPTION
Hi Team,

This PR includes following changes
- Removes eager-loading for orders and adds lazy loading(loads on page visit)
- Removes Item count from my_orders page

Jira ticket:- https://jira.crossroads.org.hk/browse/GCW-2195

Last change should be fixed in GCW-2187 => https://jira.crossroads.org.hk/browse/GCW-2187

Please review it and let me know if any other changes are required.
Thanks