### PR TITLE
disable ios build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -338,9 +338,9 @@ workflows:
             filters:
               branches:
                 only: /^(master|live)$/
-        - ios_build_and_deploy:
-            requires:
-              - test_cases
-            filters:
-              branches:
-                only: /^(master|live)$/
+        # - ios_build_and_deploy:
+        #     requires:
+        #       - test_cases
+        #     filters:
+        #       branches:
+        #         only: /^(master|live)$/


### PR DESCRIPTION
Hi Team,

Disabling ios build for now. We can enable it whenever its actually needed and again we can disable it until we find solution for billing and extra build time 

Thanks.