### PR TITLE
Fix redirection from client_information

### DIFF
--- a/app/controllers/order/client_information.js
+++ b/app/controllers/order/client_information.js
@@ -132,7 +132,7 @@ export default Ember.Controller.extend(cancelOrder, {
         });
     },
 
-    redirectToGoodsDetails(isClientInformation=false) {
+    redirectToGoodsDetails() {
       let order = this.get("order");
       let orderId = order.id;
 
@@ -140,12 +140,8 @@ export default Ember.Controller.extend(cancelOrder, {
         this.get("myOrders").set("selectedOrder", order);
         this.transitionToRoute('my_orders');
       } else {
-        if (isClientInformation) {
-          this.transitionToRoute('order.goods_details', orderId, { queryParams: { fromClientInformation: true }});
-        } else {
-          let nextRoute = `order.${this.get('order.isAppointment') ? 'goods_details' : 'schedule_details'}`;
-          this.transitionToRoute(nextRoute, orderId, { queryParams: { fromClientInformation: true }});
-        }
+        let nextRoute = `order.${this.get('order.isAppointment') ? 'goods_details' : 'schedule_details'}`;
+        this.transitionToRoute(nextRoute, orderId, { queryParams: { fromClientInformation: true }});
       }
     }
   }

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -372,6 +372,7 @@ export default {
     "transport_details_pop_up": "Add items to your cart before submitting transport details.",
     "numbers_warning": "Please enter 4 digit number.",
     "transport_details": {
+      "title": "Transport Details",
       "transport_method": "Transport method: ",
       "collect_with_own_vehicle": "We will collect with our own vehicle(s)",
       "send_item_with_driver": "We would like the items sent (recipient pays the driver)"
@@ -446,7 +447,6 @@ export default {
       "remove": "Remove"
     },
     "appointment": {
-      "title": "Appointment Details",
       "transport": "Transport",
       "self_vehicle": "Client will bring private vehicle",
       "hire_vehicle": "Client needs information about hiring vehicle",
@@ -504,7 +504,7 @@ export default {
         "no_description": "No description provided",
       },
       "schedule_summary": {
-        "title": "Logistic Details",
+        "title": "Transport Details",
         "transport": "Transport",
         "labour": "Labour",
         "labour_info": "Client understands labour requirements and can supply labour if needed.",

--- a/app/locales/zh/translations.js
+++ b/app/locales/zh/translations.js
@@ -354,6 +354,7 @@ export default {
     "transport_details_pop_up": "請在購物車中新增物資以提交運輸詳情。",
     "numbers_warning": "請輸入一個4位數字。",
     "transport_details": {
+      "title": "預約詳情",
       "transport_method": "運輸方式: ",
       "collect_with_own_vehicle": "我會自行安排運輸接收",
       "send_item_with_driver": "我會安排GoGoVan代為接收（服務使用者付費）"
@@ -427,7 +428,6 @@ export default {
       "remove": "移除"
     },
     "appointment": {
-      "title": "預約詳情",
       "transport": "運輸方式",
       "self_vehicle": "服務對象將自攜帶車輛",
       "hire_vehicle": "服務對象需要有關僱用車輛的信息",

--- a/app/models/order.js
+++ b/app/models/order.js
@@ -39,11 +39,11 @@ export default Model.extend({
   isCancelled: Ember.computed.equal("state", "cancelled"),
   i18n: Ember.inject.service(),
 
-  isAppointment: Ember.computed('bookingTypeId', function(){
+  isAppointment: Ember.computed('bookingType', function(){
     return this.get('bookingType.isAppointment');
   }),
 
-  isOnlineOrder: Ember.computed('bookingTypeId', function(){
+  isOnlineOrder: Ember.computed('bookingType', function(){
     return this.get('bookingType.isOnlineOrder');
   }),
 

--- a/app/templates/order/schedule_details.hbs
+++ b/app/templates/order/schedule_details.hbs
@@ -24,7 +24,7 @@
               {{/if}}
             </section>
              <section class="middle tab-bar-section">
-              <h1 class="title"> {{t 'order.appointment.title'}} </h1>
+              <h1 class="title"> {{t 'order.transport_details.title'}} </h1>
             </section>
             <section {{action "cancelBookingPopUp"}} id="cancel-booking-link" class="right-large inline-content right-align">
               {{t "cancel"}}

--- a/app/templates/request_purpose.hbs
+++ b/app/templates/request_purpose.hbs
@@ -12,7 +12,7 @@
                   {{fa-icon "angle-left"}}
                   {{#if (is-equal previousRouteName "my_orders")}}
                     {{#link-to 'my_orders' classNames="back"}}{{t "back"}}{{/link-to}}
-                  {{else if isOnlineOrderDraft }}
+                  {{else if model.isOnlineOrderDraft }}
                      {{#link-to "cart" classNames="back"}}{{t "back"}}{{/link-to}}
                   {{else}}
                     {{#link-to "home" classNames="back"}}{{t "back"}}{{/link-to}}

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "ember-qunit-notifications": "0.1.0",
-    "jquery-mockjax": "~2.0.1"
+    "jquery-mockjax": "~2.5.0"
   },
   "resolutions": {
     "jquery-placeholder": "^2.1.0"

--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "ember-qunit-notifications": "0.1.0",
-    "jquery-mockjax": "~2.5.0"
+    "jquery-mockjax": "~2.0.1"
   },
   "resolutions": {
     "jquery-placeholder": "^2.1.0"

--- a/tests/acceptance/book-appointment-test.js
+++ b/tests/acceptance/book-appointment-test.js
@@ -1,17 +1,21 @@
 import Ember from 'ember';
+import _ from 'lodash';
 import { module, test } from 'qunit';
 import startApp from 'browse/tests/helpers/start-app';
 import { make, mockFindAll } from 'ember-data-factory-guy';
 
-var App, order, gogo_van, user, user_profile, orderPurpose1, orderPurpose2 , organisation, pkg, ordersPackage, mocks, goodcityRequest, benificiary, identity_type1, package_type, bookingType, purpose, requestPurposeUrl, goodsDetailsUrl, appointmentPageUrl, clientInfoUrl, bookingSuccessUrl, confirmBookingUrl, orderTransport;
+var App, order, gogo_van, user, user_profile, orderPurpose1, orderPurpose2 , organisation, pkg, ordersPackage, mocks, goodcityRequest, benificiary, identity_type1, package_type, purpose, requestPurposeUrl, goodsDetailsUrl, scheduleDetailsUrl, appointmentPageUrl, clientInfoUrl, bookingSuccessUrl, confirmBookingUrl, orderTransport;
+var BookingTypes = {
+  onlineOrder: { id:1, identifier: 'online-order'},
+  appointment: { id:2, identifier: 'appointment'}
+};
 
-module('Acceptance | BookAppointment', {
+module('Acceptance | BookAppointment - OnlineOrder', {
   beforeEach: function() {
     App = startApp();
     user = make("user");
     organisation = make("organisation");
     pkg = make('package');
-    bookingType = make("booking_type");
     purpose = make("purpose");
     ordersPackage = make("orders_package", { quantity: 1, state: "requested", package: pkg,
       packageId: pkg.id, order: order});
@@ -45,12 +49,21 @@ module('Acceptance | BookAppointment', {
       mockFindAll("gogovan_transport").returns({json: {gogovan_transports: [gogo_van.toJSON({includeId: true})]}}),
       mockFindAll('order').returns({ json: {orders: [order.toJSON({includeId: true})],
         packages: [pkg.toJSON({includeId: true})], orders_packages: [ordersPackage.toJSON({includeId: true})]}}),
-      mockFindAll("booking_type").returns({json: {booking_types: [bookingType.toJSON({includeId: true})]}}),
+      mockFindAll("booking_type").returns({json: {booking_types: _.values(BookingTypes)}}),
       mockFindAll("purpose").returns({json: {booking_types: [purpose.toJSON({includeId: true})]}})
+    );
+    let date = moment(new Date()).format('YYYY-MM-DD'); // jshint ignore:line
+    let timestamp = moment(new Date()).format(); // jshint ignore:line
+    let slots = [{id: null, isClosed: false, note: "", quota: 3, remaining: 3, timestamp }];
+    mocks.push(
+      $.mockjax({url: '/api/v1/appointment_slots/calenda*', type: 'GET', status: 200, responseText:{
+          appointment_calendar_dates: [{date: date, slots: slots, isClosed: false}]
+      }})
     );
     requestPurposeUrl = '/request_purpose';
     clientInfoUrl = `/order/${order.id}/client_information`;
     goodsDetailsUrl = `/order/${order.id}/goods_details`;
+    scheduleDetailsUrl = `/order/${order.id}/schedule_details`;
     appointmentPageUrl = `/order/${order.id}/schedule_details`;
     confirmBookingUrl = `/order/${order.id}/confirm_booking`;
     bookingSuccessUrl = `/order/${order.id}/booking_success`;
@@ -228,12 +241,79 @@ test("Select RBCL on client info should display form for rbcl", function(assert)
   });
 });
 
-test("Filled Up client info page, should redirect to goods details page on submit", function(assert){
-  orderPurpose2 = {id: 1, purposes: [{id: 2}], order_id: order.id, designation_id: 1};
+test("Online order : Filled Up client info page, should redirect to schedule details page on submit", function(assert){
+  orderPurpose2 = {id: 1, purposes: [{id: 2}], order_id: order.id, designation_id: 1, booking_type_id: BookingTypes.onlineOrder.id};
   assert.expect(2);
+
   mocks.push(
     $.mockjax({url: '/api/v1/order*', type: 'GET', status: 201,responseText: {
         order: order.toJSON({includeId: true}),
+        orders_purposes: [orderPurpose2],
+        user: user.toJSON({includeId: true}),
+        goodcity_requests: []
+      }
+    })
+  );
+  visit('/');
+  andThen(function(){
+    visit(clientInfoUrl);
+  });
+  andThen(function(){
+    click('.custom_radio_buttons .for-client');
+  });
+  andThen(function(){
+    fillIn("#hk-id-number", "1234");
+  });
+  andThen(function(){
+    fillIn("#hk-id-firstName", "Test");
+  });
+  andThen(function(){
+    fillIn("#hk-id-lastName", "John");
+  });
+  andThen(function(){
+    fillIn("#mobile", "98876353");
+  });
+  andThen(function(){
+    mocks.push(
+      $.mockjax({url: '/api/v1/order*', type: 'PUT', status: 201,responseText: {
+        order: order.toJSON({includeId: true}),
+        orders_purposes: [orderPurpose2],
+        user: user.toJSON({includeId: true})}
+      }),
+      $.mockjax({url: '/api/v1/beneficiarie*', type: 'POST', status: 201,
+        responseText: {
+          beneficiary: benificiary,
+          identity_types: [identity_type1]
+        }
+      })
+    );
+    click('#client-info-submit');
+    andThen(function(){
+      let updated_gc_req = {id: goodcityRequest.id, code_id: package_type.id, order_id: order.id, package_type_id: package_type.id};
+      let location = {id:12, building:'26Med', area:'B2', stockit_id:null};
+      mocks.push(
+        $.mockjax({url: 'api/v1/goodcity_requests/*', type:'PUT', status: 201,
+          responseText:{
+            code: [package_type.toJSON({includeId: true})],
+            goodcity_request: updated_gc_req,
+            locations: [location]
+          }
+        })
+      );
+      assert.equal(currentURL(), scheduleDetailsUrl);
+      assert.equal(Ember.$('.title').text().trim(), "Transport Details");
+    });
+  });
+});
+
+test("Appointment : Filled Up client info page, should redirect to goods details page on submit", function(assert){
+  orderPurpose2 = {id: 1, purposes: [{id: 2}], order_id: order.id, designation_id: 1 };
+  assert.expect(2);
+
+  let appointment = _.extend({}, order.toJSON({includeId: true}), { booking_type_id: BookingTypes.appointment.id });
+  mocks.push(
+    $.mockjax({url: '/api/v1/order*', type: 'GET', status: 201,responseText: {
+        order: appointment,
         orders_purposes: [orderPurpose2],
         user: user.toJSON({includeId: true}),
         goodcity_requests: []


### PR DESCRIPTION
Somehow there was the following condition : 
```javascript
if (isClientInformation) {
          this.transitionToRoute('order.goods_details', orderId, { queryParams: { fromClientInformation: true }});
}
```

which doesn't make sense, I suspect it's during a merge/conflict that it stayed there. This PR just removes it (and changes the title of a page as per requirements)