### PR TITLE
Fix minor issue when empty cart it should not go to account details if clicked on submit.

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -201,9 +201,7 @@ export default Ember.Controller.extend({
     },
 
     checkout() {
-      if (this.accountDetailsComplete()) {
-        this.submitCart();
-      } else {
+      if (!this.accountDetailsComplete() && this.get("hasCartItems")) {
         this.set("showCartDetailSidebar", false);
         this.transitionToRoute("account_details", {
           queryParams: {
@@ -211,6 +209,8 @@ export default Ember.Controller.extend({
             bookAppointment: false
           }
         });
+      } else {
+        this.submitCart();
       }
     },
 


### PR DESCRIPTION
Hello team is PR fixes a minor issue, where if there are no items in cart, on clicking submit button it should show the message box asking to add items to the cart, instead of redirecting to the account_details.
Thanks