### PR TITLE
GCW-2550 fix account details submission do not work if mobile is blank

### DIFF
--- a/app/controllers/account_details.js
+++ b/app/controllers/account_details.js
@@ -126,11 +126,12 @@ export default Ember.Controller.extend({
   },
 
   mobileParam(user) {
-    var mobile = user && user.get("mobile");
+    let mobile = user && user.get("mobile");
+    let mobilePhone = this.get("mobilePhone");
     if (mobile && mobile.length) {
       return mobile;
-    } else {
-      return "+852" + this.get("mobilePhone");
+    } else if (mobilePhone.length) {
+      return "+852" + mobilePhone;
     }
   },
 


### PR DESCRIPTION
Hi Team,

This PR fixes issue of account details form submission throwing an invalid mobile number error and allows to submit the form even if the mobile number field is blank as per requirement.

Please review.

Thanks.