### PR TITLE
Fully load an order before navigating to the detail page

### DIFF
--- a/app/controllers/my_orders.js
+++ b/app/controllers/my_orders.js
@@ -48,5 +48,40 @@ export default applicationController.extend({
         this.get("flashMessage").show("order.flash_submit_message");
       }
     }
-  )
+  ),
+
+  preloadOrder(order) {
+    this.startLoading();
+    return this.get("store")
+      .findRecord("order", order.get("id"), { reload: true })
+      .catch(e => {
+        this.stopLoading();
+        return Ember.RSVP.reject(e);
+      })
+      .then(res => {
+        this.stopLoading();
+        return res;
+      });
+  },
+
+  actions: {
+    viewOrder(order) {
+      const id = order.get("id");
+      this.preloadOrder(order).then(() => {
+        this.transitionToRoute("orders.detail", id);
+      });
+    },
+
+    editOrder(order) {
+      const id = order.get("id");
+      this.preloadOrder(order).then(() => {
+        this.transitionToRoute("request_purpose", {
+          queryParams: {
+            bookAppointment: this.get("isAppointmentDraft"),
+            orderId: id
+          }
+        });
+      });
+    }
+  }
 });

--- a/app/models/order.js
+++ b/app/models/order.js
@@ -20,7 +20,7 @@ export default Model.extend({
   detailType: attr("string"),
   districtId: attr("number"),
   messages: hasMany("message", { async: false }),
-  ordersPurposes: hasMany("ordersPurpose", { async: false }),
+  ordersPurposes: hasMany("orders_purpose", { async: false }),
   beneficiaryId: attr("string"),
   bookingTypeId: attr("number"),
   beneficiary: belongsTo("beneficiary", { async: true }),
@@ -28,7 +28,6 @@ export default Model.extend({
   goodcityRequests: hasMany("goodcity_request", { async: false }),
   district: belongsTo("district", { async: false }),
   bookingType: belongsTo("booking_type", { async: false }),
-  purposeIds: attr(),
 
   isGoodCityOrder: Ember.computed.equal("detailType", "GoodCity"),
   isDraft: Ember.computed.equal("state", "draft"),

--- a/app/templates/my_orders.hbs
+++ b/app/templates/my_orders.hbs
@@ -20,13 +20,13 @@
       <ul class="list list-items">
         {{#each arrangedOrders as |order|}}
             {{#if order.isDraft}}
-              {{#link-to 'request_purpose' (query-params bookAppointment=isAppointmentDraft orderId=order.id)}}
+              <div {{ action 'editOrder' order}}>
                 {{ partial 'order/order_block'}}
-              {{/link-to}}
+              </div>
             {{else}}
-              {{#link-to "orders.detail" order.id}}
+              <div {{ action 'viewOrder' order}}>
                 {{ partial 'order/order_block'}}
-              {{/link-to}}
+              </div>
             {{/if}}
         {{/each}}
       </ul>

--- a/app/utils/helpers.js
+++ b/app/utils/helpers.js
@@ -2,15 +2,12 @@
 /* Helper functions */
 /********************/
 
-const containsAny = (str, substrings) => {
+export function containsAny(str, substrings) {
   for (var i = 0; i !== substrings.length; i++) {
-     var substring = substrings[i];
-     if (str.indexOf(substring) !== - 1) {
-       return true;
-     }
+    var substring = substrings[i];
+    if (str.indexOf(substring) !== -1) {
+      return true;
+    }
   }
   return false;
-};
-
-
-export default containsAny;
+}


### PR DESCRIPTION
Some edge cases appeared when live updates came into play (with the new api changes), we now fetch the record before navigating to the details page.
The detail pages know not to re-fetch a record that is already loaded.
It's important to make at least one findRecord call to populate everything we need, it's hard to move it to the details route because it is inherited by sub-pages, which risks causing multiple unneeded downloads (not totally convinced about this approach)