### PR TITLE
fix pages shifting to right

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -48,7 +48,7 @@ export default Ember.Controller.extend({
     "showSidebar",
     "moveSidebarToRight",
     function() {
-      let url = window.location.pathname;
+      let url = window.location.href;
       return !containsAny(url, [
         "request_purpose",
         "account_details",


### PR DESCRIPTION
Earlier we were using `window.location.pathname`
but `pathname` returns `"/android_asset/www/index.html"` in case of android app. and hence the issue 
and `pathname` returns `"/page_name"` in case of web

`href` will return `"file:///android_asset/www/index.html#/request_purpose?bookAppointment=true"`
in case of mobile app
and will return `"http://localhost:4202/request_purpose?bookAppointment=true"`

in both case it will serve the purpose. So please review this, and let me know if any changes if required.