### PR TITLE
Settings service + OnlineOrder booking margin config

### DIFF
--- a/app/controllers/order/schedule_details.js
+++ b/app/controllers/order/schedule_details.js
@@ -12,12 +12,21 @@ export default Ember.Controller.extend(cancelOrder, {
   order: Ember.computed.alias("model.order"),
   orderTransport: Ember.computed.alias("model.orderTransport"),
   myOrders: Ember.inject.controller(),
+  settings: Ember.inject.service(),
   selectedId: null,
   selectedTimeId: null,
   selectedDate: null,
   timeSlotNotSelected: false,
   isEditing: false,
   showOrderSlotSelection: false,
+
+  bookingMargin: Ember.computed(function() {
+    // To allow time to prepare orders, we set a saftety margin
+    // of days in which clients cannot book anything.
+    return this.get("settings").readNumber(
+      "browse.online_order.timeslots.booking_margin"
+    );
+  }),
 
   isAppointment: Ember.computed("order", function() {
     return this.get("order.isAppointment");
@@ -36,8 +45,10 @@ export default Ember.Controller.extend(cancelOrder, {
   }),
 
   onlineOrderPickupSlots: Ember.computed("available_dates", function() {
-    let availableDates = this.get("available_dates").appointment_calendar_dates;
     let results = [];
+    let availableDates = this.get(
+      "available_dates"
+    ).appointment_calendar_dates.slice(this.get("bookingMargin"));
 
     const atHour = (d, h) => {
       d = new Date(d);

--- a/app/models/goodcity_setting.js
+++ b/app/models/goodcity_setting.js
@@ -1,0 +1,7 @@
+import Model from "ember-data/model";
+import attr from "ember-data/attr";
+
+export default Model.extend({
+  key: attr("string"),
+  value: attr("string")
+});

--- a/app/services/settings.js
+++ b/app/services/settings.js
@@ -1,0 +1,84 @@
+import Ember from "ember";
+import _ from "lodash";
+import "../computed/local-storage";
+
+const NOT_EMPTY = val => val && val.length > 0;
+const TO_NUMBER = val => Number(val);
+const IS_NUMBER = val => !isNaN(TO_NUMBER(val));
+
+export default Ember.Service.extend({
+  store: Ember.inject.service(),
+
+  /**
+   *
+   * Settings are loaded from the API in order to configure the
+   * behaviour of the app remotely.
+   * Any key defined on the backend will override the local values
+   *
+   * A local value *must* be defined, the service will throw an error
+   * otherwise. This behaviour is meant to ensure we have fallback values
+   * if the remote config is missing
+   *
+   *
+   * Add any new configuration keys below
+   *         ;;;;;
+   *         ;;;;;
+   *       ..;;;;;..
+   *        ':::::'
+   *          ':`
+   */
+  defaults: {
+    "browse.online_order.timeslots.booking_margin": 2
+  },
+
+  // ---- Access methods
+
+  readString(key) {
+    return this.__readValue(key, {
+      validator: NOT_EMPTY
+    });
+  },
+
+  readNumber(key) {
+    return this.__readValue(key, {
+      parser: TO_NUMBER,
+      validator: IS_NUMBER
+    });
+  },
+
+  // ---- Helpers
+
+  __validate(val, validator) {
+    const validators = _.compact(_.flatten([validator]));
+    return _.every(validators, fn => fn(val));
+  },
+
+  __assertExists(key) {
+    const defaults = this.get("defaults");
+    if (_.has(defaults, key)) {
+      return;
+    }
+
+    throw new Error(`
+      Settings '${key}' has not been defined locally.
+      Please define a local default value before using it
+    `);
+  },
+
+  __readValue(key, options = {}) {
+    const defaults = this.get("defaults");
+    const { validator, parser = _.identity } = options;
+
+    this.__assertExists(key);
+
+    const record = this.get("store")
+      .peekAll("goodcity_setting")
+      .findBy("key", key);
+
+    const val = record && record.get("value");
+    if (val && this.__validate(val, validator)) {
+      return parser(val);
+    }
+    return defaults[key];
+  }
+});

--- a/app/services/settings.js
+++ b/app/services/settings.js
@@ -3,8 +3,15 @@ import _ from "lodash";
 import "../computed/local-storage";
 
 const NOT_EMPTY = val => val && val.length > 0;
+const TO_STRING = val => String(val);
 const TO_NUMBER = val => Number(val);
 const IS_NUMBER = val => !isNaN(TO_NUMBER(val));
+const TO_BOOL = val => {
+  if (_.isString(val)) {
+    return /^true$/i.test(val);
+  }
+  return Boolean(val);
+};
 
 export default Ember.Service.extend({
   store: Ember.inject.service(),
@@ -33,8 +40,15 @@ export default Ember.Service.extend({
 
   // ---- Access methods
 
+  readBoolean(key) {
+    return this.__readValue(key, {
+      parser: TO_BOOL
+    });
+  },
+
   readString(key) {
     return this.__readValue(key, {
+      parser: TO_STRING,
       validator: NOT_EMPTY
     });
   },
@@ -79,6 +93,6 @@ export default Ember.Service.extend({
     if (val && this.__validate(val, validator)) {
       return parser(val);
     }
-    return defaults[key];
+    return parser(defaults[key]);
   }
 });

--- a/config/environment.js
+++ b/config/environment.js
@@ -64,7 +64,8 @@ module.exports = function(environment) {
         "territory",
         "package_category",
         "donor_condition",
-        "package"
+        "package",
+        "goodcity_setting"
       ],
       PRELOAD_AUTHORIZED_TYPES: [
         "gogovan_transport",


### PR DESCRIPTION
If you haven't yet reviewed the new server changes, please do so first here : https://github.com/crossroads/api.goodcity/pull/750 , things will make more sense.

This PR adds a `settings` service, which is just a combination of key value pairs which the app can read. The catch is that if one of those settings has been defined on the backend, it will use that value instead (basically we are able to override configs remotely).

Currently I've only added on configuration : `browse.online_order.timeslots.booking_margin`
It defines a margin of days before which users can book their online order in. It was based on a comment from Nokia, she mentioned that if someone books for the next day, that wouldn't give the staff enough days to prepare.
That margin will certainly change in the future, so making it configurable is going to save us the effort of cherry picking and releasing hot fixes.