### PR TITLE
Fix weird sidebar behaviours

### DIFF
--- a/app/components/app-canvas.js
+++ b/app/components/app-canvas.js
@@ -3,47 +3,44 @@ import ObserveScreenResize from "./observe-screen-resize";
 
 export default ObserveScreenResize.extend({
   cartscroll: Ember.inject.service(),
-  isHomePage: Ember.computed("router", function() {
-    return this.get("router").currentPath === "home";
-  }),
+  isHomePage: Ember.computed(function() {
+    return Ember.getOwner(this)
+      .lookup("controller:application")
+      .get("isHomePage");
+  }).volatile(),
 
-  observeScreen: function() {
-    this.get("cartscroll").resize();
-    if (!this.screenResized()) {
-      let offCanvasWrap = Ember.$(".off-canvas-wrap");
-      offCanvasWrap.addClass("move-right");
-      if (this.get("isHomePage")) {
-        offCanvasWrap.addClass("home-page");
-      } else {
-        offCanvasWrap.removeClass("home-page");
-        offCanvasWrap.addClass("move-left");
-      }
-      Ember.$(".left-off-canvas-toggle").hide();
-      this.OtherScreenOffCanvas();
-    } else {
-      Ember.$(".off-canvas-wrap")
-        .removeClass("move-right")
-        .removeClass("move-left");
+  onScreenResized() {
+    if (this.get("isSmallScreen")) {
       Ember.$(".left-off-canvas-toggle").show();
-      this.smallScreenOffCanvas();
+      this.closeSideBars();
+      this.applySmallScreenSettings();
+    } else {
+      Ember.$(".left-off-canvas-toggle").hide();
+      this.showSideBar();
+      this.applyDesktopScreenSettings();
     }
+    this.get("cartscroll").resize();
   },
-  smallScreenOffCanvas: function() {
+
+  closeSideBars() {
+    Ember.$(".off-canvas-wrap")
+      .removeClass("move-right")
+      .removeClass("move-left");
+  },
+
+  showSideBar() {
+    Ember.$(".off-canvas-wrap").addClass("move-right");
+  },
+
+  applySmallScreenSettings: function() {
     Ember.$(document).foundation({ offcanvas: { close_on_click: true } });
   },
-  OtherScreenOffCanvas: function() {
+
+  applyDesktopScreenSettings: function() {
     Ember.$(document).foundation({ offcanvas: { close_on_click: false } });
   },
 
   didInsertElement() {
-    this.get("cartscroll").resize();
-    if (!this.screenResized()) {
-      this.OtherScreenOffCanvas();
-    } else {
-      this.smallScreenOffCanvas();
-      Ember.$(".off-canvas-wrap")
-        .removeClass("move-right")
-        .removeClass("move-left");
-    }
+    this.onScreenResized();
   }
 });

--- a/app/components/image-preview.js
+++ b/app/components/image-preview.js
@@ -2,23 +2,20 @@ import Ember from "ember";
 import ObserveScreenResize from "./observe-screen-resize";
 
 export default ObserveScreenResize.extend({
-
   lightGalleryObj: null,
 
-  observeScreen: function() {
-    if(!this.isDestroyed || !this.isDestroying) {
-      this.set("isSmallScreen", this.screenResized());
-      this.initializeLightgallery();
-    }
+  onScreenResized() {
+    this.initializeLightgallery();
   },
 
-  initializeLightgallery: function(){
-
-    var gallery = Ember.$("#lightGallery").data('lightGallery');
-    if(gallery) { gallery.destroy(); }
+  initializeLightgallery() {
+    var gallery = Ember.$("#lightGallery").data("lightGallery");
+    if (gallery) {
+      gallery.destroy();
+    }
 
     var lightGalleryObj = Ember.$("#lightGallery").lightGallery({
-      mode: 'lg-slide',
+      mode: "lg-slide",
       zoom: true,
       download: false,
       scale: 1,
@@ -26,11 +23,11 @@ export default ObserveScreenResize.extend({
       closable: true,
       loop: true,
       counter: true,
-      enableTouch : true,
+      enableTouch: true,
       enableDrag: true,
-      selector: '.imageZoom'
+      selector: ".imageZoom"
     });
-    this.set('lightGalleryObj', lightGalleryObj);
+    this.set("lightGalleryObj", lightGalleryObj);
   },
 
   didInsertElement() {
@@ -38,7 +35,9 @@ export default ObserveScreenResize.extend({
   },
 
   willDestroyElement() {
-    var gallery = Ember.$("#lightGallery").data('lightGallery');
-    if(gallery) { gallery.destroy(); }
+    var gallery = Ember.$("#lightGallery").data("lightGallery");
+    if (gallery) {
+      gallery.destroy();
+    }
   }
 });

--- a/app/components/observe-screen-resize.js
+++ b/app/components/observe-screen-resize.js
@@ -1,14 +1,28 @@
 import Ember from "ember";
 
 export default Ember.Component.extend({
-  screenResized: function() {
-    return matchMedia(Foundation.media_queries.small).matches &&
-      !matchMedia(Foundation.media_queries.medium).matches;
+  screenresize: Ember.inject.service(),
+
+  isSmallScreen: Ember.computed.alias("screenresize.isSmallScreen"),
+  isMediumScreen: Ember.computed.alias("screenresize.isMediumScreen"),
+
+  onScreenResized() {
+    throw "Method not implemented";
   },
 
-  initComonent: function() {
-    var updateScreen = Ember.run.bind(this, this.observeScreen);
-    window.addEventListener("resize", updateScreen);
-  }.on("init")
+  init: function() {
+    this._super(...arguments);
+    this.__updateScreen = () => {
+      if (this.isDestroyed || this.isDestroying) {
+        return;
+      }
+      this.onScreenResized();
+    };
+    window.addEventListener("resize", this.__updateScreen);
+  },
 
+  willDestroyElement() {
+    this._super(...arguments);
+    window.removeEventListener("resize", this.__updateScreen);
+  }
 });

--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -10,10 +10,11 @@ export default Ember.Controller.extend({
   subscription: Ember.inject.service(),
   messageBox: Ember.inject.service(),
   loggedInUser: false,
-  isHomePage: false,
   i18n: Ember.inject.service(),
   showSidebar: true,
-  moveSidebarToRight: true,
+  isHomePage: Ember.computed("currentPath", function() {
+    return this.get("currentPath") === "home";
+  }),
 
   app_id: config.APP.ANDROID_APP_ID,
   ios_app_id: config.APP.APPLE_APP_ID,
@@ -48,23 +49,19 @@ export default Ember.Controller.extend({
     return !!this.session.get("authToken");
   }),
 
-  showOffCanvas: Ember.computed(
-    "showSidebar",
-    "moveSidebarToRight",
-    function() {
-      let url = window.location.href;
-      return !containsAny(url, [
-        "request_purpose",
-        "account_details",
-        "schedule_details",
-        "goods_details",
-        "client_information",
-        "search_code",
-        "confirm_booking",
-        "booking_success"
-      ]);
-    }
-  ),
+  showOffCanvas: Ember.computed("showSidebar", function() {
+    let url = window.location.href;
+    return !containsAny(url, [
+      "request_purpose",
+      "account_details",
+      "schedule_details",
+      "goods_details",
+      "client_information",
+      "search_code",
+      "confirm_booking",
+      "booking_success"
+    ]);
+  }),
 
   addMoveLeft: Ember.computed(
     "isHomePage",

--- a/app/routes/home.js
+++ b/app/routes/home.js
@@ -6,13 +6,9 @@ export default PublicRoute.extend({
     let applicationController = this.controllerFor("application");
     controller.set("cartLength", applicationController.get("cartLength"));
     controller.set("hasCartItems", applicationController.get("hasCartItems"));
-    applicationController.set("isHomePage", true);
   },
 
   resetController: function(controller, isExiting) {
     this._super.apply(this, arguments);
-    if (isExiting) {
-      this.controllerFor("application").set("isHomePage", false);
-    }
   }
 });

--- a/app/services/screenresize.js
+++ b/app/services/screenresize.js
@@ -1,29 +1,33 @@
-import Ember from 'ember';
-import '../computed/local-storage';
+import Ember from "ember";
+import "../computed/local-storage";
+
+const MEDIA_QUERIES = {
+  SMALL: Foundation.media_queries.small,
+  MEDIUM: Foundation.media_queries.medium,
+  LARGE: Foundation.media_queries.large
+};
 
 export default Ember.Service.extend({
-  isSmallScreen: false,
-  isMediumScreen: false,
-
-  screenResized: function() {
-    return matchMedia(Foundation.media_queries.small).matches &&
-      !matchMedia(Foundation.media_queries.medium).matches;
+  init() {
+    this._super(...arguments);
+    window.addEventListener("resize", () => {
+      this.notifyPropertyChange("isSmallScreen");
+      this.notifyPropertyChange("isMediumScreen");
+    });
   },
 
-  screenResizedMedium: function() {
-    return matchMedia(Foundation.media_queries.small).matches &&
-      matchMedia(Foundation.media_queries.medium).matches && !matchMedia(Foundation.media_queries.large).matches;
-  },
+  isSmallScreen: Ember.computed(function() {
+    return (
+      matchMedia(MEDIA_QUERIES.SMALL).matches &&
+      !matchMedia(MEDIA_QUERIES.MEDIUM).matches
+    );
+  }),
 
-  observeScreen: function() {
-    this.set("isSmallScreen", this.screenResized());
-    this.set("isMediumScreen", this.screenResizedMedium());
-  },
-
-  initComponent: function() {
-    this.observeScreen();
-    var updateScreen = Ember.run.bind(this, this.observeScreen);
-    window.addEventListener("resize", updateScreen);
-  }.on("init")
-
+  isMediumScreen: Ember.computed(function() {
+    return (
+      matchMedia(MEDIA_QUERIES.SMALL).matches &&
+      matchMedia(MEDIA_QUERIES.MEDIUM).matches &&
+      !matchMedia(MEDIA_QUERIES.LARGE).matches
+    );
+  })
 });

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -19,7 +19,7 @@
   {{#app-canvas}}
     <div class="row application-layout">
       <div class="large-12 medium-12 columns collapse no-padding" id="content">
-        <div class="{{if (is-and showOffCanvas moveSidebarToRight)'off-canvas-wrap move-right' ''}} {{if addMoveLeft 'move-left' ''}} {{if isHomePage "home-page" ""}}" data-offcanvas>
+        <div class="off-canvas-wrap {{if addMoveLeft 'move-left' ''}} {{if isHomePage "home-page" ""}}" data-offcanvas>
           <div class="inner-wrap">
             {{#if showSidebar}}
               {{partial "sidebar"}}


### PR DESCRIPTION
### the problem

We would have those weird moments where the sidebar would appear without being triggered, this PR aims the fix that.

### the cause

The problem came from the fact that there were conflicts over CSS classes that were bound via ember's `{{ }}` interpolation, which were also being manipulated through jQuery.
Ideally, we would **_never_** use `$(...)`.
However, because that part of the code is based on foundation, things already happen in the background out of our control and we're kinda forced to use it sadly 😢

### the changes

- I removed the bound property that is already being controller manually through the screen resize observer
- removed as much DOM manipulation code I could, we really don't want any in the app
- removed some old unused properties and fixed some that were simply not working
- renamed a lot of properties/functions which made absolutely no sense to me
- modified the observer component to use the screenresize service, no point in re-writing the wheel
- ensure the components remove the event listeners on destruction