### PR TITLE
redirect-users-to-login-instead-of-showing-modal

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -8,7 +8,6 @@ export default {
   by: "By",
   ok: "OK",
   go_to_top: "Go to top",
-  must_login: "You must log in!",
   okay: "Okay",
   unexpected_error: "Something went wrong",
   QuotaExceededError:

--- a/app/locales/zh/translations.js
+++ b/app/locales/zh/translations.js
@@ -5,7 +5,6 @@ export default {
   "company.name": "國際十字路會",
   by: "了解",
   ok: "確定",
-  must_login: "請登入！",
   unexpected_error: "出錯了",
   QuotaExceededError:
     "網站可能在瀏覽器的<b>私密瀏覽模式</b>下不能正常運作。請嘗試</br><ul><li><a href='http://www.apple.com/itunes/' style='color: black!important; background-color: #dee4eb !important;'>下載iOS 應用程式</a></li><li>使用瀏覽器的常規模式</li><li>使用Chrome 的私密瀏覽模式</li></ul>",

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -36,13 +36,9 @@ export default Ember.Route.extend(preloadDataMixin, {
         object.unlessIncludesCurrentPath()
       ) {
         object.set("isMustLoginAlreadyShown", true);
-        object
-          .get("messageBox")
-          .alert(object.get("i18n").t("must_login"), () => {
-            object.session.clear();
-            object.store.unloadAll();
-            object.transitionTo("/login");
-          });
+        object.session.clear();
+        object.store.unloadAll();
+        object.transitionTo("/login");
       } else if (
         authToken &&
         (currentPath.indexOf("login") >= 0 ||
@@ -92,15 +88,13 @@ export default Ember.Route.extend(preloadDataMixin, {
     });
   },
 
-  showLoginError() {
+  redirectToLogin() {
     if (this.session.get("isLoggedIn")) {
       this.session.clear();
       this.store.unloadAll();
       var loginController = this.controllerFor("login");
       loginController.set("attemptedTransition", this.get("previousRoute"));
-      this.get("messageBox").alert(this.get("i18n").t("must_login"), () =>
-        this.transitionTo("login")
-      );
+      this.transitionTo("login");
     }
   },
 
@@ -146,7 +140,7 @@ export default Ember.Route.extend(preloadDataMixin, {
       } else if (reason.name === "NotFoundError" && reason.code === 8) {
         return false;
       } else if (status === 401) {
-        this.showLoginError();
+        this.redirectToLogin();
       } else {
         this.showSomethingWentWrong(reason);
       }

--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -10,7 +10,6 @@ export default Ember.Route.extend(preloadDataMixin, {
   i18n: Ember.inject.service(),
   previousRoute: null,
   isErrPopUpAlreadyShown: false,
-  isMustLoginAlreadyShown: false,
 
   unlessIncludesCurrentPath() {
     var currentPath = window.location.href;
@@ -30,12 +29,7 @@ export default Ember.Route.extend(preloadDataMixin, {
     var storageHandler = function(object) {
       var currentPath = window.location.href;
       var authToken = window.localStorage.getItem("authToken");
-      if (
-        !authToken &&
-        !object.get("isMustLoginAlreadyShown") &&
-        object.unlessIncludesCurrentPath()
-      ) {
-        object.set("isMustLoginAlreadyShown", true);
+      if (!authToken && object.unlessIncludesCurrentPath()) {
         object.session.clear();
         object.store.unloadAll();
         object.transitionTo("/login");

--- a/app/routes/authorize.js
+++ b/app/routes/authorize.js
@@ -1,17 +1,12 @@
-import Ember from 'ember';
+import Ember from "ember";
 
 export default Ember.Route.extend({
-  messageBox: Ember.inject.service(),
-  i18n: Ember.inject.service(),
-
   beforeModel(transition) {
-    if (!this.session.get('isLoggedIn')) {
+    if (!this.session.get("isLoggedIn")) {
       transition.abort();
-      this.get('messageBox').alert(this.get("i18n").t('must_login'), () => {
-        var loginController = this.controllerFor('login');
-        loginController.set('attemptedTransition', transition);
-        this.transitionTo('login');
-      });
+      var loginController = this.controllerFor("login");
+      loginController.set("attemptedTransition", transition);
+      this.transitionTo("login");
       return false;
     }
     return true;


### PR DESCRIPTION
Currrently, if user is logged out and tries to visit any page, we show "You must login!" modal, which looks rude, so this PR removes that modal, and automatically redirects them to the login page.

Keeping in mind which the user was trying to visit, post login user is redirected to that page.