### PR TITLE
Fix IE11 issue the ID number field in client info

### DIFF
--- a/app/templates/request/hk_identity_type_details.hbs
+++ b/app/templates/request/hk_identity_type_details.hbs
@@ -11,7 +11,7 @@
         <label id="id-initials"> P12 </label>
       </div>
       <div class="columns small-3 medium-3 large-2">
-          {{numeric-input name="hk_id" id="hk-id-number" value=identityNumber minlength="4" maxlength="4" placeholder="XXXX" required='true'}}
+          {{numeric-input name="hk_id" id="hk-id-number" value=identityNumber minlength="4" maxlength="4" placeholder="XXXX" required='true' pattern=".{4,}" autoFocus=true}}
       </div>
       <div class="columns small-6 medium-6 large-8 x-with-brackets">
         (X)

--- a/app/templates/request/rbcl_identity_type_details.hbs
+++ b/app/templates/request/rbcl_identity_type_details.hbs
@@ -11,7 +11,7 @@
         <label id="id-initials"> RBCL </label>
       </div>
       <div class="columns small-3 medium-2 large-2">
-          {{numeric-input name="hk_id" id="hk-id-number" value=identityNumber minlength="4" maxlength="4" placeholder="XXXX" required='true'}}
+          {{numeric-input name="hk_id" id="hk-id-number" value=identityNumber minlength="4" maxlength="4" placeholder="XXXX" required='true' pattern=".{4,}" autoFocus=true}}
       </div>
       <div class="columns small-6 medium-6 large-8 x-with-brackets">
         / XX


### PR DESCRIPTION
Fixed the issue that is mentioned in the below ticket where previously the field was not showing a warning message:
https://jira.crossroads.org.hk/browse/GCW-2565
