### PR TITLE
fix cross icon for ios safari

### DIFF
--- a/app/styles/templates/_item.scss
+++ b/app/styles/templates/_item.scss
@@ -223,6 +223,7 @@
 
   &.item-remove-icon{
     margin-top: 1.5rem;
+    cursor: pointer;
 
     .remove-icon {
       @media #{$small-only} {


### PR DESCRIPTION
Hi Team,

This PR fixes cross icon on image is not clickable on ios mobile safari. 

https://jira.crossroads.org.hk/browse/GCW-2676

Please review.

Thanks.