### PR TITLE
change the backlink name on item page to "Back to Search"

### DIFF
--- a/.ember-cli
+++ b/.ember-cli
@@ -5,5 +5,6 @@
 
     Setting `disableAnalytics` to true will prevent any data from being sent.
   */
-  "disableAnalytics": false
+  "disableAnalytics": false,
+  "port": 4202
 }

--- a/app/controllers/item.js
+++ b/app/controllers/item.js
@@ -5,6 +5,7 @@ export default Ember.Controller.extend({
   messageBox: Ember.inject.service(),
   application: Ember.inject.controller(),
   queryParams: ["categoryId", "sortBy"],
+  prevPath: null,
   categoryId: null,
   cart: Ember.inject.service(),
   sortBy: "createdAt",
@@ -70,6 +71,14 @@ export default Ember.Controller.extend({
 
   categoryObj: Ember.computed("categoryId", function() {
     return this.store.peekRecord("package_category", this.get("categoryId"));
+  }),
+
+  linkDisplayName: Ember.computed("prevPath", function() {
+    let prevPath = this.get("prevPath");
+    if (prevPath === "search_goods") {
+      return this.get("i18n").t("search_goods.back");
+    }
+    return this.get("categoryObj.name");
   }),
 
   selectedSort: Ember.computed("sortBy", function() {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -206,7 +206,8 @@ export default {
     placeholder: "Search Goods",
     title: "Search Results",
     done: "Done",
-    search_info: "You can search for goods. E.g.'table' or 'stroller'"
+    search_info: "You can search for goods. E.g.'table' or 'stroller'",
+    back: "< Back to search"
   },
 
   account: {

--- a/app/locales/zh/translations.js
+++ b/app/locales/zh/translations.js
@@ -193,7 +193,8 @@ export default {
     placeholder: "Search Goods",
     title: "Search Results",
     done: "Done",
-    search_info: "You can search for goods. E.g.'table' or 'stroller'"
+    search_info: "You can search for goods. E.g.'table' or 'stroller'",
+    back: "< Back to search"
   },
 
   account: {

--- a/app/routes/package.js
+++ b/app/routes/package.js
@@ -1,23 +1,25 @@
-import PublicRoute from './browse_pages';
+import PublicRoute from "./browse_pages";
 
 export default PublicRoute.extend({
-
   model(params) {
-    return this.store.peekRecord('package', params["id"]);
+    return this.store.peekRecord("package", params["id"]);
   },
 
   renderTemplate() {
-    this.render('item', {controller: 'package'});
+    this.render("item", { controller: "package" });
   },
 
-  setupController(controller, model){
+  setupController(controller, model) {
     this._super(...arguments);
-    if(model) {
-      controller.set('model', model);
-      controller.set('item', model);
+    if (model) {
+      controller.set("model", model);
+      controller.set("item", model);
+      controller.set("prevPath", this.router.currentPath);
       controller.set("previewUrl", model.get("previewImageUrl"));
     }
-    this.controllerFor('application').set('pageTitle',
-    this.get('i18n').t("itemdetail.view"));
+    this.controllerFor("application").set(
+      "pageTitle",
+      this.get("i18n").t("itemdetail.view")
+    );
   }
 });

--- a/app/styles/_search.scss
+++ b/app/styles/_search.scss
@@ -12,6 +12,11 @@
 }
 
 .goods_search {
+  #searchText::-ms-clear{
+    display: none;
+    width: 0;
+    height:0;
+  }
   .infinite-list-container::-webkit-scrollbar {
     width: 0 !important
   }
@@ -26,15 +31,27 @@
     padding: 0 0.3em !important;
   }
   .back_button {
-    margin-top: 2% !important;
-  }
-  .back_icon{
-    display: flex;
+    @media #{$large-only} {
+      margin-top: 1.5% !important;
+    }
+    @media #{$medium-only} {
+      margin-top: 1.5% !important;
+    }
+    @media #{$xlarge-only} {
+      margin-top: 1% !important;
+    }
+    @media #{$xxlarge-only} {
+      margin-top: 1% !important;
+    }
+    .back_icon{
+      display: flex;
+    }
   }
   .search_info{
     margin-left: 5%;
     color: black;
     font-size: 0.8rem;
+    cursor: default;
     @media #{$small-only} {
       font-size: 0.6rem;
     }
@@ -94,7 +111,7 @@
     cursor: pointer;
 
     @media #{$small-only} {
-      font-size: 1.2rem;
+      font-size: 1rem;
       padding: 0.5rem 0.3rem 0.5rem;
       top: 0.41rem;
     }
@@ -113,6 +130,8 @@
     margin-left: 15%;
     @media #{$small-only} {
       margin-top: 20%;
+      margin-left: unset;
+      font-size: 0.7em;
     }
   }
 

--- a/app/styles/templates/_item.scss
+++ b/app/styles/templates/_item.scss
@@ -41,7 +41,6 @@
     }
     img {
       display: block;
-      padding-bottom: 1rem;
       @media #{$small-only}{
         padding-bottom: 0;
       }

--- a/app/templates/item.hbs
+++ b/app/templates/item.hbs
@@ -6,7 +6,7 @@
     <div class="row">
       <div class="large-8 medium-8 small-12 columns hide-for-small package_catogory_header">
         <div class="package_back_button">
-          <span class="package_category_link" {{action 'back'}}>{{categoryObj.name}}</span>
+          <span class="package_category_link" {{action 'back'}}>{{linkDisplayName}}</span>
           <span class="package-type">\ {{item.packageType.name}}</span>
         </div>
       </div>
@@ -101,7 +101,11 @@
 
           <div class="item_details item_categories">
             {{#each item.allPackageCategories key="@index" as |category|}}
-              {{#link-to 'package_category' category class="category_link"}}<span class="underline_text">{{category.name}}</span>{{/link-to}}
+              {{#link-to 'package_category' (if category.parentCategory category.parentCategory category) class="category_link"}}
+                <span class="underline_text">
+                  {{category.name}}
+                </span>
+              {{/link-to}}
             {{/each}}
           </div>
         </div>


### PR DESCRIPTION
This PR fixes one issue which TIM reported, that on clicking item from search page, the back link appears as category name, but it takes back to search page. 
So changes have been made such that, when user comes from search_page, it'll show "Back to search" otherwise it will show category name as the back link.
Also, this PR contains some css fixes for search page. Please review. 
Thanks