### PR TITLE
Quick fix for the account details page navigation bug

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -161,17 +161,19 @@ export default Ember.Controller.extend(cancelOrderMixin, {
 
     checkout() {
       const accountComplete = this.get("session").accountDetailsComplete();
-      if (!accountComplete && this.get("hasCartItems")) {
+      const loggedIn = this.get("session.isLoggedIn");
+
+      if (loggedIn && !accountComplete && this.get("hasCartItems")) {
         this.set("showCartDetailSidebar", false);
-        this.transitionToRoute("account_details", {
+        return this.transitionToRoute("account_details", {
           queryParams: {
             onlineOrder: true,
             bookAppointment: false
           }
         });
-      } else {
-        this.submitCart();
       }
+
+      this.submitCart();
     },
 
     showItemDetails(record) {

--- a/app/models/package.js
+++ b/app/models/package.js
@@ -42,12 +42,12 @@ export default Model.extend(cloudinaryImage, {
   isDispatched: Ember.computed.bool("stockitSentOn"),
 
   isAvailable: Ember.computed("isDispatched", "allowWebPublish", function() {
-    return (
+    return Boolean(
       !this.get("isDispatched") &&
-      (this.get("allowWebPublish") ||
-        (this._internalModel._data &&
-          this._internalModel._data.allowWebPublish)) &&
-      this.get("quantity")
+        (this.get("allowWebPublish") ||
+          (this._internalModel._data &&
+            this._internalModel._data.allowWebPublish)) &&
+        this.get("quantity")
     );
   }),
 


### PR DESCRIPTION
Here's the fix for one of the `account_details` page.

Note: I think the whole navigation flow needs some work, but making a "hotfix", since we're a bit short on time before the launch event.

## The problem

A lot of this is hard to see when reading to code, because we need to follow the transitions all the way, but here's a breakdown of what was happening:

For a new user, the current logging flow looked like this : 

`[auth page] -> [verification page] -> [account details page]`

And the "submit cart" flow as a `guest` looked like this: 

`[login flow] -> [account details page] -> [request_purpose]`

So If I write the whole thing it essentially resulted in this :

`[auth page] -> [verification page] -> [account details page] -> [account details page] -> [request_purpose]`

The `account_details` page would be there twice, and when someone would confirm the details for the second time, the server answers with "email already exists" (or such)

Some people would also not click a second time, and see the accoun_details page as "stuck"


