### PR TITLE
Fix one issue, where if parent category is selected, child category r…

### DIFF
--- a/app/controllers/item.js
+++ b/app/controllers/item.js
@@ -145,6 +145,8 @@ export default Ember.Controller.extend({
       );
       if (parentId) {
         this.get("packageCategory").set("selectedCategoryId", category);
+      } else {
+        this.get("packageCategory").set("selectedCategoryId", null);
       }
     },
 


### PR DESCRIPTION
Once child category is selected, and we open the item page, on clicking the parent category, eg ~'Furniture', child category remains selected. 

This PR fixes that issue. 