### PR TITLE
FIX=> IE fix for order selection UI

### DIFF
--- a/app/controllers/submitted_order_selection.js
+++ b/app/controllers/submitted_order_selection.js
@@ -31,7 +31,7 @@ export default Ember.Controller.extend(asyncTasksMixin, {
 
   isPackageSubmittableOrder(order) {
     const orderState = order.get("state");
-    return ["submitted", "processing"].includes(orderState);
+    return ["submitted", "processing"].indexOf(orderState) >= 0;
   },
 
   async checkoutCart() {


### PR DESCRIPTION
Hi Team,
This fix is for IE on Order selection UI. Replaced `includes` with `indexOf`. 