### PR TITLE
GCW-2298 adding yarn lock file to sync with goodcity lib

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4658,7 +4658,7 @@ cordova-lib@6.5.0:
 
 "cordova-lib@https://github.com/crossroads/goodcity-lib.git#master":
   version "0.0.0"
-  resolved "https://github.com/crossroads/goodcity-lib.git#822c1f8587c4c76f7cafb9717cf1c3cff5b0fc62"
+  resolved "https://github.com/crossroads/goodcity-lib.git#9b2e6f15f32f02fc3c168562b2add6e85bd73084"
   dependencies:
     bower "^1.8.8"
     codeclimate-test-reporter "^0.5.0"


### PR DESCRIPTION
Hi Team,

This PR contains the yarn.lock file needed to sync goodcity-lib . with the browse app.

Please review.