### PR TITLE
Gcw 2980 account details page not visible ie

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,28 +355,28 @@ workflows:
               # - test_cases
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|GCW-2980-account-details-page-not-visible-ie)$/
         - www-deploy:
             requires:
               - www_build
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|GCW-2980-account-details-page-not-visible-ie)$/
         - ember_cordova_build:
             requires:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|GCW-2980-account-details-page-not-visible-ie)$/
         - android_build_and_deploy:
             requires:
               - ember_cordova_build
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|GCW-2980-account-details-page-not-visible-ie)$/
         - ios_build_and_deploy:
             requires:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|GCW-2980-account-details-page-not-visible-ie)$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,28 +355,28 @@ workflows:
               # - test_cases
             filters:
               branches:
-                only: /^(master|live|account-details-page-not-visible-ie)$/
+                only: /^(master|live)$/
         - www-deploy:
             requires:
               - www_build
             filters:
               branches:
-                only: /^(master|live|account-details-page-not-visible-ie)$/
+                only: /^(master|live)$/
         - ember_cordova_build:
             requires:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live|account-details-page-not-visible-ie)$/
+                only: /^(master|live)$/
         - android_build_and_deploy:
             requires:
               - ember_cordova_build
             filters:
               branches:
-                only: /^(master|live|account-details-page-not-visible-ie)$/
+                only: /^(master|live)$/
         - ios_build_and_deploy:
             requires:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live|account-details-page-not-visible-ie)$/
+                only: /^(master|live)$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -355,28 +355,28 @@ workflows:
               # - test_cases
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|account-details-page-not-visible-ie)$/
         - www-deploy:
             requires:
               - www_build
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|account-details-page-not-visible-ie)$/
         - ember_cordova_build:
             requires:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|account-details-page-not-visible-ie)$/
         - android_build_and_deploy:
             requires:
               - ember_cordova_build
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|account-details-page-not-visible-ie)$/
         - ios_build_and_deploy:
             requires:
               - package_dependencies
             filters:
               branches:
-                only: /^(master|live)$/
+                only: /^(master|live|account-details-page-not-visible-ie)$/

--- a/app/routes/post_login.js
+++ b/app/routes/post_login.js
@@ -9,6 +9,7 @@ export default Route.extend({
   session: service(),
   preloadService: service(),
   session: service(),
+  browserDetect: service(),
   isBookAppointment: false,
 
   beforeModel(params) {
@@ -44,7 +45,13 @@ export default Route.extend({
         this.transitionTo("browse");
       }
     } else {
-      window.location.replace("/account_details");
+      if (this.get("browserDetect").ie()) {
+        window.location.replace("/account_details");
+        debugger;
+      } else {
+        this.transitionTo("account_details");
+        debugger;
+      }
     }
   }
 });

--- a/app/routes/post_login.js
+++ b/app/routes/post_login.js
@@ -15,10 +15,6 @@ export default Route.extend({
     this.set("isBookAppointment", params.queryParams.bookAppointment);
   },
 
-  model() {
-    return this.get("preloadService").preloadData();
-  },
-
   loadIfAbsent(modelName, id) {
     let cachedRecord = this.store.peekRecord(modelName, id);
     if (cachedRecord) {
@@ -48,7 +44,7 @@ export default Route.extend({
         this.transitionTo("browse");
       }
     } else {
-      this.transitionTo("account_details");
+      window.location.replace("/account_details");
     }
   }
 });

--- a/app/routes/post_login.js
+++ b/app/routes/post_login.js
@@ -47,10 +47,8 @@ export default Route.extend({
     } else {
       if (this.get("browserDetect").ie()) {
         window.location.replace("/account_details");
-        debugger;
       } else {
         this.transitionTo("account_details");
-        debugger;
       }
     }
   }

--- a/app/services/browser-detect.js
+++ b/app/services/browser-detect.js
@@ -1,0 +1,10 @@
+import Service from "@ember/service";
+
+export default Service.extend({
+  ie() {
+    return (
+      navigator.userAgent.indexOf("MSIE") != -1 ||
+      !!document.documentMode == true
+    );
+  }
+});

--- a/app/templates/account_details.hbs
+++ b/app/templates/account_details.hbs
@@ -117,7 +117,7 @@
                         {{/if}}
                       </div>
                       {{else}}
-                      {{input value=email value=email classNames="number_input center_align_placeholder" id="email" type="email" required='true'}}
+                      {{input value=email classNames="number_input center_align_placeholder" id="email" type="email" required='true'}}
                       {{/if}}
                     </div>
                     <div class="small-12 columns input-error warning_empty">


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2980

### What does this PR do?

Bug:
This PR fixes the issue of 
1. when new user login he is not redirected to the accout_detail page on ie.
2. On IE11, on the account details page for a new user, the email field contains '[object object]'

could you please review.

