### PR TITLE
Gcw 2985 Fixed addition of zero quantity item in cart

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -162,6 +162,10 @@ export default Controller.extend(cancelOrderMixin, {
     },
 
     checkout() {
+      if (this.get("cart.isEmpty")) {
+        return;
+      }
+
       const accountComplete = this.get("session").accountDetailsComplete();
       const loggedIn = this.get("session.isLoggedIn");
 

--- a/app/controllers/item.js
+++ b/app/controllers/item.js
@@ -42,8 +42,10 @@ export default Controller.extend({
       : [item];
   }),
 
-  notAvailableInStock: computed("allPackages.@each.quantity", function() {
-    let quantities = this.get("allPackages").map(pkg => pkg.get("quantity"));
+  notAvailableInStock: computed("allPackages.@each.onHandQuantity", function() {
+    let quantities = this.get("allPackages").map(pkg =>
+      pkg.get("onHandQuantity")
+    );
     return _.sum(quantities) === 0;
   }),
 

--- a/app/controllers/item.js
+++ b/app/controllers/item.js
@@ -4,6 +4,7 @@ import { alias, empty, gt, sort } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
 import Controller, { inject as controller } from "@ember/controller";
 import config from "../config/environment";
+import _ from "lodash";
 
 export default Controller.extend({
   messageBox: service(),
@@ -39,6 +40,11 @@ export default Controller.extend({
     return item.get("isItem")
       ? item.get("packages").filterBy("isAvailable")
       : [item];
+  }),
+
+  notAvailableInStock: computed("allPackages.@each.quantity", function() {
+    let quantities = this.get("allPackages").map(pkg => pkg.get("quantity"));
+    return _.sum(quantities) === 0;
   }),
 
   categoryObj: computed("categoryId", function() {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -429,7 +429,8 @@ export default {
 
   item: {
     request_item: "Request Item",
-    remove_item: "Remove Item"
+    remove_item: "Remove Item",
+    unavailable_item: "This item is no longer available in stock."
   },
 
   cart_content: {

--- a/app/locales/zh/translations.js
+++ b/app/locales/zh/translations.js
@@ -396,7 +396,8 @@ export default {
 
   item: {
     request_item: "申請項目",
-    remove_item: "刪除項目"
+    remove_item: "刪除項目",
+    unavailable_item: "This item is no longer available in stock."
   },
 
   cart_content: {

--- a/app/models/package.js
+++ b/app/models/package.js
@@ -9,6 +9,7 @@ import cloudinaryImage from "../mixins/cloudinary_image";
 
 export default Model.extend(cloudinaryImage, {
   quantity: attr("number"),
+  onHandQuantity: attr("number"),
   length: attr("number"),
   width: attr("number"),
   height: attr("number"),

--- a/app/styles/templates/_item.scss
+++ b/app/styles/templates/_item.scss
@@ -39,6 +39,15 @@
     }
   }
 
+  .item-unavailable {
+    font-size: 14px;
+    margin-top: -1rem;
+    color: #f34d4f;
+    font-weight: bold;
+    display: block;
+    margin-bottom: 1rem;
+  }
+
   .view-image {
     @media #{$small-only} {
       margin-left: -1rem;

--- a/app/styles/templates/_item.scss
+++ b/app/styles/templates/_item.scss
@@ -42,7 +42,7 @@
   .item-unavailable {
     font-size: 14px;
     margin-top: -1rem;
-    color: #f34d4f;
+    color: $coral-red;
     font-weight: bold;
     display: block;
     margin-bottom: 1rem;

--- a/app/templates/cart_content/_full_view.hbs
+++ b/app/templates/cart_content/_full_view.hbs
@@ -9,7 +9,7 @@
       </a>
     </div>
     <div class="small-6 columns">
-      <a {{action 'checkout'}} class="button expand">
+      <a {{action 'checkout'}} class="button expand" disabled={{cart.isEmpty}}>
         {{t "cart_content.submit_request"}}
       </a>
     </div>

--- a/app/templates/item.hbs
+++ b/app/templates/item.hbs
@@ -97,7 +97,7 @@
 
         {{#if notAvailableInStock}}
         <button class="request-item disabled" disabled> {{t "item.request_item"}} </button>
-        <i class="item-unavailable">This item is no longer available in stock.</i>
+        <i class="item-unavailable"> {{t "item.unavailable_item"}} </i>
         {{else if presentInCart}}
         <button class="request-item" {{action 'remove' item target=cart}}> {{t "item.remove_item"}} </button>
         {{else}}

--- a/app/templates/item.hbs
+++ b/app/templates/item.hbs
@@ -85,7 +85,7 @@
           {{/if}}
           {{/if}}
           <div class="item_details">
-            {{t "itemdetail.quantity"}}: {{package.quantity}}
+            {{t "itemdetail.quantity"}}: {{package.onHandQuantity}}
           </div>
           <div class="item_details">
             {{#if package.isDimensionPresent}}

--- a/app/templates/item.hbs
+++ b/app/templates/item.hbs
@@ -89,13 +89,16 @@
           </div>
           <div class="item_details">
             {{#if package.isDimensionPresent}}
-              {{t "itemdetail.size"}}: {{package.dimensions}}
+            {{t "itemdetail.size"}}: {{package.dimensions}}
             {{/if}}
           </div>
         </p>
         {{/each}}
 
-        {{#if presentInCart}}
+        {{#if notAvailableInStock}}
+        <button class="request-item disabled" disabled> {{t "item.request_item"}} </button>
+        <i class="item-unavailable">This item is no longer available in stock.</i>
+        {{else if presentInCart}}
         <button class="request-item" {{action 'remove' item target=cart}}> {{t "item.remove_item"}} </button>
         {{else}}
         <button class="request-item" {{action 'add' item target=cart}}> {{t "item.request_item"}} </button>


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-2985

### What does this PR do?
This PR fixes two issue:

1. In the Browse app, it does not fetch the items with zero quantity in the response. But there are some cases where item page is open in browser and it is dispatched from the stock app, which changes the quantity to zero but the `Request Item` button is still active.
Fixed this issue by disabling the `Request Item` button 

![Screen Shot 2020-02-18 at 12 16 04 PM](https://user-images.githubusercontent.com/1950768/74800510-b11ca400-52f9-11ea-85e6-f73f77e514be.png)

2. On cart show page `/cart`, even though there are no items in cart, `Submit order` button is active and which shows message on click as 
![Screen Shot 2020-02-18 at 12 21 21 PM](https://user-images.githubusercontent.com/1950768/74800608-02c52e80-52fa-11ea-9190-d078fbe0176f.png)

This seems bit confusing, as User have not added any item at all. 

Fixed it by disabling the `submit order` button.

![Screen Shot 2020-02-19 at 9 09 10 AM](https://user-images.githubusercontent.com/1950768/74800660-2e481900-52fa-11ea-82ab-7628e73057bb.png)


### Impacted Areas

`/cart` and item page
