### PR TITLE
 GCW-2920 avoid creation of empty order

### DIFF
--- a/app/controllers/application.js
+++ b/app/controllers/application.js
@@ -49,6 +49,7 @@ export default Controller.extend(cancelOrderMixin, {
   cartscroll: service(),
 
   hasCartItems: alias("cart.isNotEmpty"),
+
   cartLength: alias("cart.groupedPackages.length"),
 
   isUserLoggedIn: computed("session.authToken", function() {
@@ -169,7 +170,7 @@ export default Controller.extend(cancelOrderMixin, {
       const accountComplete = this.get("session").accountDetailsComplete();
       const loggedIn = this.get("session.isLoggedIn");
 
-      if (loggedIn && !accountComplete && this.get("hasCartItems")) {
+      if (loggedIn && !accountComplete && this.get("cart.hasValidItems")) {
         this.set("showCartDetailSidebar", false);
         return this.transitionToRoute("account_details", {
           queryParams: {

--- a/app/controllers/item.js
+++ b/app/controllers/item.js
@@ -151,17 +151,6 @@ export default Controller.extend({
       }
     },
 
-    requestItem(item) {
-      this.get("cart").add(item);
-      later(
-        this,
-        function() {
-          this.get("application").send("displayCart");
-        },
-        50
-      );
-    },
-
     setChildCategory(category) {
       this.setAndRedirectToCategory(category);
     },


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-2920

### What does this PR do?

**Issue 1:**
When on click of `Request Item` gives any error for any edge case, it still adds that item to cart. And allows to create order and eventually creates order with no item.

Fix: Unload requested-package record from cart if receive any error from backend

**Issue 2**
For logged-in users, while cart submit, it does not check item's availability. And allows to create order with no item.

Fix: For logged-in user, updated condition to check for cart having items and availability of those items. 

### Impacted Areas

Cart page