### PR TITLE
Remove quantity field

### DIFF
--- a/app/models/item.js
+++ b/app/models/item.js
@@ -16,10 +16,10 @@ export default Model.extend(cloudinaryImage, {
   donorCondition: belongsTo("donor_condition", { async: false }),
   saleable: attr("boolean"),
 
-  quantity: computed("packages.@each.quantity", function() {
+  quantity: computed("packages.@each.availableQuantity", function() {
     let totalQuantity = 0;
     this.get("packages").forEach(function(pkg) {
-      totalQuantity = totalQuantity + pkg.get("quantity");
+      totalQuantity = totalQuantity + pkg.get("availableQuantity");
     });
     return totalQuantity;
   }),

--- a/app/models/orders_package.js
+++ b/app/models/orders_package.js
@@ -12,10 +12,6 @@ export default Model.extend({
   packageId: attr("number"),
   createdAt: attr("date"),
 
-  availableQty: computed("quantity", function() {
-    return this.get("quantity");
-  }),
-
   isSingleQuantity: computed("quantity", function() {
     return this.get("quantity") === 1;
   })

--- a/app/models/package.js
+++ b/app/models/package.js
@@ -8,8 +8,12 @@ import { belongsTo, hasMany } from "ember-data/relationships";
 import cloudinaryImage from "../mixins/cloudinary_image";
 
 export default Model.extend(cloudinaryImage, {
-  quantity: attr("number"),
+  onHandQuantity: attr("number"),
+  designatedQuantity: attr("number"),
+  dispatchedQuantity: attr("number"),
   availableQuantity: attr("number"),
+  quantity: alias("availableQuantity"), // Temporary fallback, do not use
+
   length: attr("number"),
   width: attr("number"),
   height: attr("number"),
@@ -31,7 +35,7 @@ export default Model.extend(cloudinaryImage, {
   //This is fix for live update for ticket GCW-1632(only implemented on singleton packages, nee to change for qty packages)
   updateAllowwebpublishQtyIfDesignated: observer(
     "allowWebPublish",
-    "quantity",
+    "availableQuantity",
     "orderId",
     function() {
       once(this, function() {
@@ -50,7 +54,7 @@ export default Model.extend(cloudinaryImage, {
         (this.get("allowWebPublish") ||
           (this._internalModel._data &&
             this._internalModel._data.allowWebPublish)) &&
-        this.get("quantity")
+        this.get("availableQuantity")
     );
   }),
 

--- a/tests/acceptance/item-test.js
+++ b/tests/acceptance/item-test.js
@@ -168,7 +168,9 @@ test("should redirect item page and Display details", function(assert) {
     assert.equal(
       $(".main-section .item_details:eq(1)")
         .text()
-        .indexOf(item_with_packages.get("packages.firstObject.quantity")) > 0,
+        .indexOf(
+          item_with_packages.get("packages.firstObject.availableQuantity")
+        ) > 0,
       true
     );
 

--- a/tests/factories/package.js
+++ b/tests/factories/package.js
@@ -1,25 +1,28 @@
-import FactoryGuy from 'ember-data-factory-guy';
-import './item';
-import './package_type';
-import './orders_package';
+import FactoryGuy from "ember-data-factory-guy";
+import "./item";
+import "./package_type";
+import "./orders_package";
 
-FactoryGuy.define('package', {
+FactoryGuy.define("package", {
   sequences: {
-    id: (num)=> num + 100
+    id: num => num + 100
   },
   default: {
-    id:       FactoryGuy.generate('id'),
-    quantity: 1,
-    length:   10,
-    width:    10,
-    height:   10,
-    inventoryNumber: 'E00001',
-    item:     FactoryGuy.belongsTo('item'),
-    packageType:  FactoryGuy.belongsTo('package_type'),
-    notes:    "example",
-    state:    "expected",
+    id: FactoryGuy.generate("id"),
+    length: 10,
+    width: 10,
+    height: 10,
+    inventoryNumber: "E00001",
+    item: FactoryGuy.belongsTo("item"),
+    packageType: FactoryGuy.belongsTo("package_type"),
+    notes: "example",
+    state: "expected",
     allowWebPublish: true,
-    ordersPackages:     FactoryGuy.hasMany('orders_package')
+    ordersPackages: FactoryGuy.hasMany("orders_package"),
+    availableQuantity: 1,
+    onHandQuantity: 1,
+    designatedQuantity: 0,
+    dispatchedQuantity: 0
   }
 });
 

--- a/tests/unit/models/item-test.js
+++ b/tests/unit/models/item-test.js
@@ -105,12 +105,12 @@ test("isAvailable: returns true if all packages are available", function(assert)
   run(function() {
     package1 = store.createRecord("package", {
       id: 1,
-      quantity: 2,
+      availableQuantity: 2,
       isAvailable: true
     });
     package2 = store.createRecord("package", {
       id: 2,
-      quantity: 2,
+      availableQuantity: 2,
       isAvailable: true
     });
     model.get("packages").pushObjects([package1, package2]);
@@ -119,7 +119,7 @@ test("isAvailable: returns true if all packages are available", function(assert)
   assert.equal(model.get("isAvailable"), true);
 });
 
-test("quantity: returns total quantity of all packages", function(assert) {
+test("availableQuantity: returns total availableQuantity of all packages", function(assert) {
   assert.expect(1);
   var package1, package2;
 
@@ -127,13 +127,14 @@ test("quantity: returns total quantity of all packages", function(assert) {
   var store = this.store();
 
   run(function() {
-    package1 = store.createRecord("package", { id: 1, quantity: 2 });
-    package2 = store.createRecord("package", { id: 2, quantity: 2 });
+    package1 = store.createRecord("package", { id: 1, availableQuantity: 2 });
+    package2 = store.createRecord("package", { id: 2, availableQuantity: 2 });
     model.get("packages").pushObjects([package1, package2]);
   });
 
-  var totalQty = package1.get("quantity") + package2.get("quantity");
-  assert.equal(model.get("quantity"), totalQty);
+  var totalQty =
+    package1.get("availableQuantity") + package2.get("availableQuantity");
+  assert.equal(model.get("availableQuantity"), totalQty);
 });
 
 test("isUnavailableAndDesignated: returns true if all packages are unavailable and designated", function(assert) {
@@ -146,12 +147,12 @@ test("isUnavailableAndDesignated: returns true if all packages are unavailable a
   run(function() {
     package1 = store.createRecord("package", {
       id: 1,
-      quantity: 2,
+      availableQuantity: 2,
       isUnavailableAndDesignated: true
     });
     package2 = store.createRecord("package", {
       id: 2,
-      quantity: 2,
+      availableQuantity: 2,
       isUnavailableAndDesignated: true
     });
     model.get("packages").pushObjects([package1, package2]);
@@ -170,12 +171,12 @@ test("isUnavailableAndDesignated: returns false if all packages are not unavaila
   run(function() {
     package1 = store.createRecord("package", {
       id: 1,
-      quantity: 2,
+      availableQuantity: 2,
       isUnavailableAndDesignated: true
     });
     package2 = store.createRecord("package", {
       id: 2,
-      quantity: 2,
+      availableQuantity: 2,
       isUnavailableAndDesignated: false
     });
     model.get("packages").pushObjects([package1, package2]);
@@ -194,7 +195,7 @@ test("images: returns blank array if associated package do not have any image", 
   run(function() {
     package1 = store.createRecord("package", {
       id: 1,
-      quantity: 2,
+      availableQuantity: 2,
       isUnavailableAndDesignated: true
     });
     model.get("packages").pushObjects([package1]);
@@ -212,7 +213,7 @@ test("favouriteImage: Returns first fav image", function(assert) {
 
   run(function() {
     item = store.createRecord("item", { id: 1, saleable: true });
-    package1 = store.createRecord("package", { id: 1, quantity: 2 });
+    package1 = store.createRecord("package", { id: 1, availableQuantity: 2 });
     model.get("packages").pushObjects([package1]);
     image = store.createRecord("image", {
       id: 1,
@@ -232,7 +233,7 @@ test("displayImage: Returns image to be dispayed", function(assert) {
 
   run(function() {
     item = store.createRecord("item", { id: 1, saleable: true });
-    package1 = store.createRecord("package", { id: 1, quantity: 2 });
+    package1 = store.createRecord("package", { id: 1, availableQuantity: 2 });
     model.get("packages").pushObjects([package1]);
     image = store.createRecord("image", {
       id: 1,

--- a/tests/unit/models/order-test.js
+++ b/tests/unit/models/order-test.js
@@ -90,7 +90,7 @@ test("orderItems: returns order package if package do not have sibling", functio
   store = this.store();
 
   run(function() {
-    package1 = store.createRecord("package", { id: 1, quantity: 1 });
+    package1 = store.createRecord("package", { id: 1, availableQuantity: 1 });
     ordersPackage1 = store.createRecord("orders_package", {
       id: 1,
       state: "dispatched",
@@ -115,12 +115,12 @@ test("orderItems: returns order item if package have sibling", function(assert) 
     item = store.createRecord("item", { id: 1, saleable: true });
     package1 = store.createRecord("package", {
       id: 1,
-      quantity: 1,
+      availableQuantity: 1,
       item: item
     });
     package2 = store.createRecord("package", {
       id: 2,
-      quantity: 1,
+      availableQuantity: 1,
       item: item
     });
     ordersPackage1 = store.createRecord("orders_package", {
@@ -145,7 +145,7 @@ test("orderItems: returns order item if hasSibling is true", function(assert) {
     item = store.createRecord("item", { id: 1, saleable: true });
     package1 = store.createRecord("package", {
       id: 1,
-      quantity: 1,
+      availableQuantity: 1,
       item: item,
       hasSiblingPackages: true
     });

--- a/tests/unit/models/orders_packages-test.js
+++ b/tests/unit/models/orders_packages-test.js
@@ -25,9 +25,7 @@ test("Relationship with other models", function(assert) {
 });
 
 test("Checking computed properties", function(assert) {
-  assert.expect(2);
   var orders_package = this.subject({ state: "designated", quantity: 6 });
-  assert.equal(orders_package.get("availableQty"), 6);
   assert.equal(orders_package.get("isSingleQuantity"), false);
 });
 

--- a/tests/unit/models/package-test.js
+++ b/tests/unit/models/package-test.js
@@ -17,7 +17,6 @@ test("item relationship", function(assert) {
   var pkg = this.subject().store.modelFor("package");
   var relationship = get(pkg, "relationshipsByName").get("item");
 
-
   assert.equal(relationship.key, "item");
   assert.equal(relationship.kind, "belongsTo");
 });
@@ -100,7 +99,7 @@ test("image: returns favourite image", function(assert) {
   store = this.store();
 
   run(function() {
-    package1 = store.createRecord("package", { id: 1, quantity: 2 });
+    package1 = store.createRecord("package", { id: 1, availableQuantity: 2 });
     image = store.createRecord("image", {
       id: 1,
       favourite: true,
@@ -118,7 +117,7 @@ test("otherImages", function(assert) {
   store = this.store();
 
   run(function() {
-    package1 = store.createRecord("package", { id: 1, quantity: 2 });
+    package1 = store.createRecord("package", { id: 1, availableQuantity: 2 });
     image1 = store.createRecord("image", {
       id: 1,
       favourite: true,
@@ -142,7 +141,7 @@ test("sortedImages: Returns sorted images", function(assert) {
   store = this.store();
 
   run(function() {
-    package1 = store.createRecord("package", { id: 1, quantity: 2 });
+    package1 = store.createRecord("package", { id: 1, availableQuantity: 2 });
     image1 = store.createRecord("image", {
       id: 1,
       favourite: true,
@@ -162,7 +161,7 @@ test("sortedImages: Returns sorted images", function(assert) {
 test("isAvailable: Checks package is available or not", function(assert) {
   var package1 = this.subject({
     id: 1,
-    quantity: 1,
+    availableQuantity: 1,
     isDispatched: false,
     allowWebPublish: true
   });
@@ -175,7 +174,7 @@ test("isAvailable: Checks package is available or not", function(assert) {
 test("isUnavailableAndDesignated: Checks is package unavailable and designated", function(assert) {
   var package1 = this.subject({
     id: 1,
-    quantity: 1,
+    availableQuantity: 1,
     isDispatched: false,
     allowWebPublish: false
   });

--- a/tests/unit/models/package-type-test.js
+++ b/tests/unit/models/package-type-test.js
@@ -34,8 +34,11 @@ test("_packages: Returns all packages", function(assert) {
   model = this.subject();
 
   run(function() {
-    package1 = store.createRecord("package", { id: 1, quantity: 1 });
-    package2 = store.createRecord("package", { id: 2, quantity: 1 });
+    package1 = store.createRecord("package", { id: 1, availableQuantity: 1 });
+    package2 = store.createRecord("package", {
+      id: 2,
+      quaavailableQuantityntity: 1
+    });
   });
 
   assert.equal(model.get("_packages.length"), 2);
@@ -50,7 +53,7 @@ test("getItemPackageList: it returns single packages with no siblings", function
   run(function() {
     package1 = store.createRecord("package", {
       id: 1,
-      quantity: 1,
+      availableQuantity: 1,
       isAvailable: true,
       hasSiblingPackages: false
     });
@@ -71,7 +74,7 @@ test("getItemPackageList: list of associated items if package has sibling", func
     item = store.createRecord("item", { id: 1, saleable: true });
     package1 = store.createRecord("package", {
       id: 1,
-      quantity: 1,
+      availableQuantity: 1,
       isAvailable: true,
       hasSiblingPackages: true,
       item: item


### PR DESCRIPTION
This PR is dependant on https://github.com/crossroads/api.goodcity/pull/926

## Changes

- Addition of the following fields to the `item` model (which is actually a `package`)
    * `availableQuantity`
    * `onHandQuantity`
    * `dispatchedQuantity`
    * `designatedQuantity`
- The `quantity` field is now an alias to `availableQuantity` (as a temporary safeguard)
- Changed all the reads of old quantities I found to the new properties