### PR TITLE
GCW-3029-Blank message breaking the chat issue is fixed

### DIFF
--- a/app/templates/orders/_message_template.hbs
+++ b/app/templates/orders/_message_template.hbs
@@ -45,7 +45,7 @@
           {{#validatable-form class="form-horizontal" onSubmit=(action 'sendMessage') as |form|}}
           <div class="row ui">
             <div class="small-9 large-10 medium-9 columns">
-              {{variable-height-textarea value=body name="body" parentDiv="message-section"}}
+              {{variable-height-textarea value=body name="body" required="true"  parentDiv="message-section"}}
             </div>
             <div class="small-3 large-2 medium-3 columns">
               {{#online-button classNames="button" onClick=(action "sendMessage") actionArgs=true}}


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3029

### What does this PR do?

Whenever ussr entered a blank space in the chat section the chat setup was breaking and was directing user towards homepage with the popup saying Something went wrong. 
Fix: Now it errors error if the message box is empty or user enters blank spaces and try to send it.

### Screenshots

![Screen Shot 2020-03-13 at 1 16 56 PM](https://user-images.githubusercontent.com/60003954/76600424-f5801600-652c-11ea-95bc-8db5eddf5dd5.png)







