### PR TITLE
Spacebar and send button pressed together dont send error now

### DIFF
--- a/app/controllers/orders/conversation.js
+++ b/app/controllers/orders/conversation.js
@@ -64,16 +64,18 @@ export default detail.extend({
   },
 
   createMessage(values) {
-    var message = this.store.createRecord("message", values);
-    message
-      .save()
-      .then(() => {
-        this.set("body", "");
-      })
-      .catch(error => {
-        this.store.unloadRecord(message);
-        throw error;
-      });
+    if (values.body) {
+      var message = this.store.createRecord("message", values);
+      message
+        .save()
+        .then(() => {
+          this.set("body", "");
+        })
+        .catch(error => {
+          this.store.unloadRecord(message);
+          throw error;
+        });
+    }
   },
 
   markReadAndScroll: function({ record }) {
@@ -108,6 +110,7 @@ export default detail.extend({
       $("textarea").trigger("blur");
       var values = this.getProperties("body");
       values.order = this.get("model");
+      values.body = values.body.trim();
       values.isPrivate = false;
       values.createdAt = new Date();
       values.sender = this.store.peekRecord(


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3029

### What does this PR do?
It fixes the edge case of chat feature. Whenever anyone tries to press spacebar and send button simultsneously in the chatbox .Something went error does not pop-up and no message is created in the store

### Screenshots


![Screen Shot 2020-03-26 at 2 08 04 PM](https://user-images.githubusercontent.com/60003954/77626360-418a7c00-6f6b-11ea-858f-aca773b76189.png)


