### PR TITLE
GCW-2601 fixed UI at cancel transport details message buttons

### DIFF
--- a/app/styles/_my_orders.scss
+++ b/app/styles/_my_orders.scss
@@ -269,11 +269,23 @@
 .cancel-appointment-buttons {
   padding: 0.5rem;
   margin-top: 1rem !important;
+
+  a {
+    @media #{$small-only} {
+      font-size: 0.8rem !important;
+    }
+    @media #{$medium-only} {
+      font-size: 0.7rem !important;
+    }
+  }
+
 }
 
 .cancel-booking-warning {
-  font-size: 1.2rem !important;
   font-weight: bolder;
+  @media #{$large-only} {
+    font-size: 1.2rem !important;
+  }
 }
 
 .cancel-booking-error {

--- a/app/templates/order/_cancel_order.hbs
+++ b/app/templates/order/_cancel_order.hbs
@@ -8,12 +8,12 @@
     {{auto-resize-textarea data-autoresize=true name="cancellation-reason" required="required" pattern=".*\S.*" class=(concat "cancel-appointment-reasons" order.id)}}
   {{/if}}
     <div class="row cancel-appointment-buttons">
-      <div class="small-6 medium-6 large-6 columns">
+      <div class="small-6 medium-5 large-6 columns">
         <a {{action 'removePopUp'}} class="button expand">
           {{t 'not_now'}}
         </a>
       </div>
-      <div class="small-6 medium-6 large-6 columns">
+      <div class="small-6 medium-7 large-6 columns">
         <a {{action 'cancelOrder'}} class="button expand">
           {{t 'cancel_booking.title'}}
         </a>


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-2601

### What does this PR do?
fixed UI at cancel transport details message buttons

![Screen Shot 2020-04-01 at 4 34 38 PM](https://user-images.githubusercontent.com/1950768/78130440-ef4bce00-7436-11ea-9345-ec5535c6dbed.png)
![Screen Shot 2020-04-01 at 4 34 49 PM](https://user-images.githubusercontent.com/1950768/78130445-f1ae2800-7436-11ea-9b2e-bf1fe04bafb9.png)
![Screen Shot 2020-04-01 at 4 36 04 PM](https://user-images.githubusercontent.com/1950768/78130446-f2df5500-7436-11ea-9844-3f4fb7524cf0.png)

