### PR TITLE
Release[0.8.2] Online order booking margin fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browse",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Small description for GoodCity Charity goes here",
   "license": "MIT",
   "author": "",


### PR DESCRIPTION
We have a setting on goodcity called `booking_margin`. That margin prevents people from selecting a pickup date on the same day or the days immediatly after. Essentially giving time for the staff to prepare the order.

Currently we do a `slice(bookingMargin)` on the days available. But if the first few days are holidays then we're not actually cutting any business days out.

This PR fixes that, by applying the `slice` to business days only.

+ general refactoring of the method