### PR TITLE
GCW-2909 Fix editing the order after cancelling it

### DIFF
--- a/app/controllers/order/schedule_details.js
+++ b/app/controllers/order/schedule_details.js
@@ -152,15 +152,21 @@ export default Controller.extend(cancelOrder, {
 
       new AjaxPromise(url, actionType, this.get("session.authToken"), {
         order_transport: this.orderTransportParams()
-      }).then(data => {
-        this.get("store").pushPayload(data);
-        loadingView.destroy();
-        if (previousRouteName === "orders.booking") {
-          this.transitionToRoute(previousRouteName, orderId);
-        } else {
-          this.transitionToRoute("order.confirm_booking", orderId);
-        }
-      });
+      })
+        .then(data => {
+          this.get("store").pushPayload(data);
+          loadingView.destroy();
+          if (previousRouteName === "orders.booking") {
+            this.transitionToRoute(previousRouteName, orderId);
+          } else {
+            this.transitionToRoute("order.confirm_booking", orderId);
+          }
+        })
+        .catch(err => {
+          this.get("messageBox").alert(err.responseJSON.error, () =>
+            this.transitionToRoute("/")
+          );
+        });
     }
   }
 });

--- a/app/controllers/order/schedule_details.js
+++ b/app/controllers/order/schedule_details.js
@@ -164,7 +164,7 @@ export default Controller.extend(cancelOrder, {
         })
         .catch(err => {
           this.get("messageBox").alert(err.responseJSON.error, () =>
-            this.transitionToRoute("/")
+            this.transitionToRoute("/my_orders")
           );
         });
     }

--- a/app/controllers/request_purpose.js
+++ b/app/controllers/request_purpose.js
@@ -127,7 +127,7 @@ export default Controller.extend(cancelOrder, {
         })
         .catch(err => {
           this.get("messageBox").alert(err.responseJSON.error, () =>
-            this.transitionToRoute("/")
+            this.transitionToRoute("/my_orders")
           );
         });
     },

--- a/app/controllers/request_purpose.js
+++ b/app/controllers/request_purpose.js
@@ -108,22 +108,28 @@ export default Controller.extend(cancelOrder, {
 
       new AjaxPromise(url, actionType, this.get("session.authToken"), {
         order: orderParams
-      }).then(data => {
-        this.get("store").pushPayload(data);
+      })
+        .then(data => {
+          this.get("store").pushPayload(data);
 
-        let orderId = data.order.id;
-        loadingView.destroy();
-        if (
-          this.get("prevPath") === "orders.booking" &&
-          this.get("editRequest")
-        ) {
-          this.transitionToRoute("orders.booking", orderId);
-          this.set("prevPath", "null");
-          this.set("editRequest", false);
-        } else {
-          this.transitionToRoute("order.client_information", orderId);
-        }
-      });
+          let orderId = data.order.id;
+          loadingView.destroy();
+          if (
+            this.get("prevPath") === "orders.booking" &&
+            this.get("editRequest")
+          ) {
+            this.transitionToRoute("orders.booking", orderId);
+            this.set("prevPath", "null");
+            this.set("editRequest", false);
+          } else {
+            this.transitionToRoute("order.client_information", orderId);
+          }
+        })
+        .catch(err => {
+          this.get("messageBox").alert(err.responseJSON.error, () =>
+            this.transitionToRoute("/")
+          );
+        });
     },
 
     back() {

--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -474,6 +474,7 @@ export default {
     representative: "Representative",
     purpose: "Purpose(s)",
     cancel_order: "Cancel Order",
+    already_cancelled: "Order is already cancelled",
     default_reason: "Changed mind",
     goodcity_order: "GoodCity Order",
     cart: "Cart",

--- a/app/locales/zh/translations.js
+++ b/app/locales/zh/translations.js
@@ -436,6 +436,7 @@ export default {
     order_delete_confirmation: "這動作會刪除所有訂單資料，並不能復原。",
     representative: "代表人員",
     cancel_order: "取消訂單",
+    already_cancelled: "Order is already cancelled",
     default_reason: "改變了主意",
     purpose: "申請目的",
     login: "登入",

--- a/app/mixins/cancel_order.js
+++ b/app/mixins/cancel_order.js
@@ -63,7 +63,7 @@ export default Mixin.create(asyncMixin, {
         if (order.get("state") === "cancelled") {
           this.get("messageBox").alert(
             this.get("i18n").t("order.already_cancelled"),
-            () => this.transitionToRoute("/")
+            () => this.transitionToRoute("/my_orders")
           );
         }
         if (order.get("isDraft")) {

--- a/app/mixins/cancel_order.js
+++ b/app/mixins/cancel_order.js
@@ -61,7 +61,7 @@ export default Mixin.create(asyncMixin, {
       order = order || this.get("order");
       if (order) {
         if (order.get("state") === "cancelled") {
-          this.get("messageBox").alert("Order cannot be cancelled.", () =>
+          this.get("messageBox").alert(i18n.t("order.already_cancelled"), () =>
             this.transitionToRoute("/")
           );
         }

--- a/app/mixins/cancel_order.js
+++ b/app/mixins/cancel_order.js
@@ -6,6 +6,7 @@ import asyncMixin from "browse/mixins/async_tasks";
 
 export default Mixin.create(asyncMixin, {
   orderService: service(),
+  messageBox: service(),
 
   deleteOrder(order) {
     this.runTask(
@@ -59,6 +60,11 @@ export default Mixin.create(asyncMixin, {
     cancelOrder(order) {
       order = order || this.get("order");
       if (order) {
+        if (order.get("state") === "cancelled") {
+          this.get("messageBox").alert("Order cannot be cancelled.", () =>
+            this.transitionToRoute("/")
+          );
+        }
         if (order.get("isDraft")) {
           this.deleteOrder(order);
         } else if (order.get("isCancelAllowed")) {

--- a/app/mixins/cancel_order.js
+++ b/app/mixins/cancel_order.js
@@ -61,8 +61,9 @@ export default Mixin.create(asyncMixin, {
       order = order || this.get("order");
       if (order) {
         if (order.get("state") === "cancelled") {
-          this.get("messageBox").alert(i18n.t("order.already_cancelled"), () =>
-            this.transitionToRoute("/")
+          this.get("messageBox").alert(
+            this.get("i18n").t("order.already_cancelled"),
+            () => this.transitionToRoute("/")
           );
         }
         if (order.get("isDraft")) {


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-2909

### What does this PR do?
This Fixes the scenario where the user is able to edit the order even after its cancelled

### Impacted Areas
Browse -> Request Purpose and Appointment screens

### Linked PR's:
https://github.com/crossroads/api.goodcity/pull/997
