### PR TITLE
GCW-2893 Fix error on vieweing package with no image

### DIFF
--- a/app/templates/components/image-preview.hbs
+++ b/app/templates/components/image-preview.hbs
@@ -13,14 +13,18 @@
     {{/if}}
   </div>
 {{else}}
-  <div id='lightGallery'>
-    <div class="imageZoom view-image hide-for-small" data-src="{{item.favouriteImage.imageUrl}}">
-      {{cloudinary-image-tag src=previewUrl}}
-    </div>
-    {{#each item.otherImages key="@index" as |image|}}
-      <div data-src={{image.imageUrl}} class="image-src hidden imageZoom">
-        <img class="thumb-image" src="{{image.thumbImageUrl}}" />
+  {{#if item.images.length}}
+    <div id='lightGallery'>
+      <div class="imageZoom view-image hide-for-small" data-src="{{item.favouriteImage.imageUrl}}">
+        {{cloudinary-image-tag src=previewUrl}}
       </div>
-    {{/each}}
-  </div>
+      {{#each item.otherImages key="@index" as |image|}}
+        <div data-src={{image.imageUrl}} class="image-src hidden imageZoom">
+          <img class="thumb-image" src="{{image.thumbImageUrl}}" />
+        </div>
+      {{/each}}
+    </div>
+  {{else}}
+    {{partial "no_image"}}
+  {{/if}}
 {{/if}}


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-2893

### What does this PR do?
Fixes the 'Something went wrong' pop-up message on clicking the package image if there is no image present

### Impacted Areas
Browse > View Package
