### PR TITLE
Removing COVID-19 notices

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -101,15 +101,11 @@ export default {
     learn_more: "Learn more",
     order_goods: {
       title: "Get immediate access to goods!",
-      covid:
-        "No self-pickup until after May 31st due to COVID-19. Delivery only.",
       subtitle: "Instant access. Have items delivered.",
       action: "Browse goods"
     },
     visit: {
       title: "Visit our distribution center",
-      covid:
-        "Book now for appointments after May 31st. Temporary closure due to COVID-19.",
       subtitle: "Choose goods in-person.",
       action: "Book appointment",
       new_appointment: "New Appointment"

--- a/app/locales/zh/translations.js
+++ b/app/locales/zh/translations.js
@@ -94,14 +94,11 @@ export default {
     learn_more: "了解更多",
     order_goods: {
       title: "隨時瀏覽選取優質物資",
-      covid:
-        "因應新冠病毒疫情，直至五月三十一日期間，未能安排自取物品。只限送貨。",
       subtitle: "隨時瀏覽，安排運送。",
       action: "瀏覽物資"
     },
     visit: {
       title: "親臨國際十字路會",
-      covid: "因應新冠病毒疫情，暫時關閉。立即登記五月三十一日後的預約。",
       subtitle: "親臨本會挑選物資",
       action: "預約時間",
       new_appointment: "新的預約"

--- a/app/templates/about.hbs
+++ b/app/templates/about.hbs
@@ -32,9 +32,6 @@
       <div class="columns large-6">
         <div class="section_text small">
           <div class="section_subtitle">{{ t "about.order_goods.title" }}</div>
-          <div class="row">
-            <div class="columns small-centered alert-box warning">{{ t "home.order_goods.covid" }}</div>
-          </div>
           <div class="step"> 1) {{ t "about.order_goods.step_1.desc" }} </div>
           <div class="step"> 2) {{ t "about.order_goods.step_2.desc" }} </div>
           <div class="step">
@@ -70,9 +67,6 @@
       <div class="columns large-6">
         <div class="section_text small">
           <div class="section_subtitle"> {{ t "about.visit.title" }} </div>
-          <div class="row">
-            <div class="columns small-centered alert-box warning">{{ t "home.visit.covid" }}</div>
-          </div>
           <div class="step light"> {{ t "about.visit.guide_intro" }} </div>
           <div class="step light">
             {{#each (range 1 4) as |num|}}

--- a/app/templates/home.hbs
+++ b/app/templates/home.hbs
@@ -35,7 +35,6 @@
         <!-- Browse goods -->
         <div class="columns home_section large-6">
           <div class="section_title"> {{ t "home.order_goods.title" }} </div>
-          <div class="columns small-8 medium-6 large-7 small-centered alert-box warning">{{ t "home.order_goods.covid" }}</div>
           <div class="section_subtitle small"> <i class="fa">{{fa-icon 'check'}}</i> {{ t "home.order_goods.subtitle" }}
             {{#link-to "about"}}{{t 'home.learn_more'}}{{/link-to}} </div>
           {{#link-to "browse"}}
@@ -48,7 +47,6 @@
         <!-- Book appointment -->
         <div class="columns home_section large-6">
           <div class="section_title"> {{ t "home.visit.title" }} </div>
-          <div class="columns small-8 medium-6 large-7 small-centered alert-box warning">{{ t "home.visit.covid" }}</div>
           <div class="section_subtitle small">
             <div><i class="fa">{{fa-icon 'check'}}</i> {{ t "home.visit.subtitle" }}
               {{#link-to "about"}}{{t 'home.learn_more'}}{{/link-to}} </div>


### PR DESCRIPTION
### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3140

### What does this PR do?

Removes the special alert notices on home page and about page related to COVID-19 closures.