### PR TITLE
GCW-2274-Back Button fixed in goods type selection page

### DIFF
--- a/app/styles/_search.scss
+++ b/app/styles/_search.scss
@@ -278,16 +278,26 @@
 .search-code,
 .goods_search {
   .back-link {
+    display: flex;
+    justify-content: center;
     text-decoration: none;
-    padding-top: 0.8rem;
+    margin-top: 0.9rem;
     color: #000 !important;
-    cursor: pointer;
-    font-size: 0.9rem;
-    padding-left: 1.5rem;
+    font-size: 1rem;
 
     @media #{$small-only} {
-      margin-left: -10%;
-      font-size: 0.7rem;
+      font-size: 0.85rem;
+    }
+  }
+
+  .back_text {
+    cursor: pointer;
+    font-size: 1.1rem;
+    margin-top: -0.2rem;
+    margin-left: 0.2rem;
+
+    @media #{$small-only} {
+      font-size: 0.95rem;
     }
   }
 

--- a/app/templates/order/search_code.hbs
+++ b/app/templates/order/search_code.hbs
@@ -1,17 +1,15 @@
 <div class="search-code">
   <div class="large-8 columns large-offset-2 medium-offset-1 medium-10 small-12">
     <div class="row fixed_search_header search-box ui items-search">
-      <div class="small-3 columns back_button">
-        <a {{action "cancelSearch"}} class="back-link">
-          <i class="fa back_icon">{{fa-icon 'angle-left'}}</i>
-          <span class="back_text">
-            {{#if inlineDescription}}
+      <div class="small-3 columns back-link">
+        {{fa-icon 'angle-left'}}
+        <div class="back_text" {{action "cancelSearch"}}  >
+          {{#if inlineDescription}}
             {{t 'cancel'}}
-            {{else}}
+          {{else}}
             {{t 'back'}}
-            {{/if}}
-          </span>
-        </a>
+          {{/if}}
+        </div>
       </div>
 
       <div class="small-9 columns">


### PR DESCRIPTION

### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-2274

### What does this PR do?
BUG: FIxed the misaligned button in chrome as well as in IE and edge browser

### Screenshots
![Screen Shot 2020-05-18 at 7 06 06 PM](https://user-images.githubusercontent.com/60003954/82220144-e1490280-993b-11ea-89ac-a502a737ae3f.png)


![Screen Shot 2020-05-18 at 7 06 20 PM](https://user-images.githubusercontent.com/60003954/82220103-d7270400-993b-11ea-9d9d-e983dc246a2c.png)

![Screen Shot 2020-05-18 at 7 05 55 PM](https://user-images.githubusercontent.com/60003954/82220419-37b64100-993c-11ea-867c-33b9314a5c48.png)
