### PR TITLE
[Release] Browse v0.8.5

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,27 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Forward release notes
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - live
+
+jobs:
+  release-notes:
+    if: github.event.pull_request.merged == 'true'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12.x
+    - name: Generate and email notes
+      run: npx @goodcity/release-notes --email-to "prabier@crossroads.org.hk,swkenworthy@crossroads.org.hk,mdgow@crossroads.org.hk" --head ${{github.event.pull_request.head.sha}} --base ${{github.event.pull_request.base.sha}} --email-subject "🚀 Browse Release 🚀"
+      env:
+        JIRA_USERNAME: ${{secrets.jira_username}}
+        JIRA_PASSWORD: ${{secrets.jira_password}}
+        SENDGRID_API_KEY: ${{secrets.sendgrid_api_key}}

--- a/app/routes/request_purpose.js
+++ b/app/routes/request_purpose.js
@@ -28,6 +28,8 @@ export default AuthorizeRoute.extend({
       : this.get("orderService").getLastDraft({ appointment: isAppointment });
 
     return loadTask.then(order => {
+      let districts = this.store.query("district", {});
+      this.store.pushPayload(districts);
       this.set("order", order);
       return order;
     });

--- a/app/templates/components/add-request.hbs
+++ b/app/templates/components/add-request.hbs
@@ -4,7 +4,7 @@
     <div class="small-12 columns add-request">
       <div class="small-7 columns" {{action "searchPackageType" request.id order.id}}>
         <label> {{t 'order.goods_details.type_label'}} </label>
-        {{input type="text" name="packageTypeDescription" value=packageTypeName pattern=".*\S.*" id=(concat 'packageTypeDescription' request.id) classNames="select-goods" required='true'}}
+        {{input type="text" name="packageTypeDescription" value=packageTypeName pattern=".*\S.*" id=(concat 'packageTypeDescription' request.id) classNames="select-goods" required='true' disabled=true}}
       </div>
       <div class="small-3 columns">
         <label> {{t 'order.goods_details.quantity_label'}} </label>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,5 +1,15 @@
 default_platform :ios
 
+class FastlaneCore::Shell
+  def error(message)
+    UI.user_error!(message)
+  end
+end
+
+def xsh(cmd)
+  sh cmd, error_callback: -> (err) { UI.user_error!(err) }
+end
+
 platform :ios do
 
   before_all do
@@ -22,7 +32,7 @@ platform :ios do
       keychain_password: ENV['KEYCHAIN_PWD']
     )
     unlock_keychain(path:"default_keychain", password:ENV['KEYCHAIN_PWD'])
-    sh "security set-keychain-settings -t 3600 -l ~/Library/Keychains/default_keychain-db"
+    xsh "security set-keychain-settings -t 3600 -l ~/Library/Keychains/default_keychain-db"
   end
 
   desc "Generate staging build (just upload to TestFairy)"
@@ -35,7 +45,7 @@ platform :ios do
   lane :production do
     raise_if_no_env_var(["APP_VERSION", "PILOT_USERNAME", "PILOT_IPA", "PILOT_TESTER_EMAIL", "ITUNESCONNECT_PASSWORD"])
     version_number = ENV["APP_VERSION"]
-    sh %{ source ~/.circlerc; bundle exec fastlane fastlane-credentials add --username $PILOT_USERNAME --password $ITUNESCONNECT_PASSWORD }
+    xsh %{ source ~/.circlerc; bundle exec fastlane fastlane-credentials add --username $PILOT_USERNAME --password $ITUNESCONNECT_PASSWORD }
     latest_testflight_build_number(version: version_number, username: ENV['PILOT_USERNAME'])
     pilot
     deliver(
@@ -50,7 +60,7 @@ platform :ios do
 
   after_all do
     # remove credentials from keychain
-    sh %{ source ~/.circlerc; bundle exec fastlane fastlane-credentials remove --username $PILOT_USERNAME }
+    xsh %{ source ~/.circlerc; bundle exec fastlane fastlane-credentials remove --username $PILOT_USERNAME }
   end
 
   error do |lane, exception|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browse",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "Small description for GoodCity Charity goes here",
   "license": "MIT",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browse",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Small description for GoodCity Charity goes here",
   "license": "MIT",
   "author": "",


### PR DESCRIPTION
# Release notes - Browse v0.8.5

**Generated on:** 2020-6-10 16:11:40
**Repository:** `git@github.com:crossroads/browse.goodcity.git`

## Tickets affected by this release

- [GCW-2848](https://jira.crossroads.org.hk/browse/GCW-2848) Stock: While creating a new order, it's possible to complete the order with an invalid goods type.
- [GCW-2537](https://jira.crossroads.org.hk/browse/GCW-2537) Browse-app(Staging): District Name changing back to English on the Chinese page.
