### PR TITLE
GCW-3352 Possible to edit request purpose on browse after closing it on stock if the page is opened beforehand

### DIFF
--- a/app/locales/en/translations.js
+++ b/app/locales/en/translations.js
@@ -7,6 +7,7 @@ export default {
   "company.name": "Crossroads Foundation",
   by: "By",
   ok: "OK",
+  access_denied: "Access Denied",
   go_to_top: "Go to top",
   okay: "Okay",
   unexpected_error: "Something went wrong",

--- a/app/locales/zh/translations.js
+++ b/app/locales/zh/translations.js
@@ -5,6 +5,7 @@ export default {
   "company.name": "國際十字路會",
   by: "了解",
   ok: "確定",
+  access_denied: "Access Denied",
   unexpected_error: "出錯了",
   not_allowed_error: "You are not allowed to perform this action.",
   QuotaExceededError:

--- a/app/templates/request_purpose.hbs
+++ b/app/templates/request_purpose.hbs
@@ -121,6 +121,11 @@
           </div>
         </div>
       </div>
+      {{#if order}}
+        {{#message-box btn1Text=(t "ok") btn1Callback=(action "back") isVisible=(if order.isEditAllowed false) classNames="popupOverlay"}}
+          <p class="bold"> {{t 'access_denied'}}</p>
+        {{/message-box}}
+      {{/if}}
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Ticket Link: 
https://jira.crossroads.org.hk/browse/GCW-3352


### What does this PR do?

BUG: It's possible to edit the Request Purpose of an order in browse after closing it on Stock if the 'edit' page is opened beforehand fix