### PR TITLE
GCW-3543-Glimmer issue fix

### DIFF
--- a/app/services/session.js
+++ b/app/services/session.js
@@ -40,7 +40,7 @@ export default ApiService.extend({
       return null;
     }
     return this.get("store").peekRecord("user", this.get("currentUserId"));
-  }).volatile(),
+  }),
 
   clear() {
     this.set("currentUserId", null);


### PR DESCRIPTION
On login,  user data was not loaded in the local storage hence cloud cart could not sync and the cart seems empty. When the user tries to add a package already present in the cloud cart (requested packages) the glimmer issue occurs