### PR TITLE
GCW-3341 Disable "add item" button for individual item of set when set has more than 1 items

### DIFF
--- a/app/controllers/package.js
+++ b/app/controllers/package.js
@@ -5,9 +5,7 @@ import { computed } from "@ember/object";
 export default packageSetController.extend({
   package: alias("model"),
 
-  packageSet: computed("package", function() {
-    return this.get("package.packageSet");
-  }),
+  packageSet: computed.alias("package.packageSet"),
 
   isPackagePartOfSet: computed("package", "packageSet.packages.[]", function() {
     let packageSet = this.get("packageSet");

--- a/app/controllers/package.js
+++ b/app/controllers/package.js
@@ -5,12 +5,12 @@ import { computed } from "@ember/object";
 export default packageSetController.extend({
   package: alias("model"),
 
-  isPackagePartOfSet: computed(
-    "package",
-    "package.packageSet.packages.[]",
-    function() {
-      let packageSet = this.get("package.packageSet");
-      return packageSet && packageSet.get("packages").length > 1;
-    }
-  )
+  packageSet: computed("package", function() {
+    return this.get("package.packageSet");
+  }),
+
+  isPackagePartOfSet: computed("package", "packageSet.packages.[]", function() {
+    let packageSet = this.get("packageSet");
+    return packageSet && packageSet.get("packages").length > 1;
+  })
 });

--- a/app/controllers/package.js
+++ b/app/controllers/package.js
@@ -5,8 +5,12 @@ import { computed } from "@ember/object";
 export default packageSetController.extend({
   package: alias("model"),
 
-  isPackagePartOfSet: computed("package", function() {
-    let packageSet = this.get("package.packageSet");
-    return packageSet && packageSet.get("packages").length > 1;
-  })
+  isPackagePartOfSet: computed(
+    "package",
+    "package.packageSet.packages.[]",
+    function() {
+      let packageSet = this.get("package.packageSet");
+      return packageSet && packageSet.get("packages").length > 1;
+    }
+  )
 });


### PR DESCRIPTION


### Ticket Link: 

https://jira.crossroads.org.hk/browse/GCW-3341

### What does this PR do?
Resolve below edge case
First create items and make sets in stock app.
Then publish one item of set view it in browse app
now later make the other item of set publish and then (without reloading) just go back and check the set and then try to add set in cart and we can see the request item button not disables for individual item
